### PR TITLE
Fix variable used before defined

### DIFF
--- a/pymyq/__init__.py
+++ b/pymyq/__init__.py
@@ -160,18 +160,18 @@ class MyQAPI:
         """List only MyQ garage door devices."""
         devices = self.get_devices()
 
+        garage_state = False
+
         if devices != False:
             for device in devices:
                 if device['MyQDeviceTypeName'] in self.SUPPORTED_DEVICE_TYPE_NAMES and device['MyQDeviceId'] == device_id:
                     dev = {}
                     for attribute in device['Attributes']:
-                       if attribute['AttributeDisplayName'] == 'doorstate':
-                            garage_state = attribute['Value']
-
-            garage_state = self.DOOR_STATE[garage_state]
-            return garage_state
-        else:
-            return False
+                        if attribute['AttributeDisplayName'] == 'doorstate':
+                            myq_garage_state = attribute['Value']
+                            garage_state = self.DOOR_STATE[myq_garage_state]
+        
+        return garage_state
 
     def close_device(self, device_id):
         """Close MyQ Device."""


### PR DESCRIPTION
In some cases `garage_state` can end up not being set by the loop, this guards against that by setting it to `False` by default