### PR TITLE
Retrieve all device states through 1 request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .mypy_cache
 Pipfile.lock
 pymyq.egg-info
+.DS_Store
+.idea/
+__pycache__/
+venv/
+

--- a/README.md
+++ b/README.md
@@ -64,9 +64,12 @@ asyncio.get_event_loop().run_until_complete(main())
 * `device_id`: the device's MyQ ID
 * `parent_id`: the device's parent device's MyQ ID
 * `name`: the name of the device
+* `available`: if device is online
 * `serial`: the serial number of the device
 * `state`: the device's current state
 * `type`: the type of MyQ device
+* `open_allowed`: if device can be opened unattended
+* `close_allowed`: if device can be closed unattended
 
 ## Methods
 
@@ -76,7 +79,8 @@ All of the routines on the `MyQDevice` class are coroutines and need to be
 * `close`: close the device
 * `open`: open the device
 * `update`: get the latest device state (which can then be accessed via the 
-`state` property)
+`state` property). Retrieval of state from cloud is will only be done if more then 5 seconds has elapsed since last 
+request. State for all devices is retrieved through (1) request.  
 
 # Disclaimer
 

--- a/example.py
+++ b/example.py
@@ -1,18 +1,40 @@
 """Run an example script to quickly test any MyQ account."""
 import asyncio
+import logging
 
 from aiohttp import ClientSession
 
 import pymyq
+from pymyq.device import STATE_CLOSED, STATE_OPEN
 from pymyq.errors import MyQError
+
+# Provide your email and password account details for MyQ.
+MYQ_ACCOUNT_EMAIL = '<EMAIL>'
+MYQ_ACCOUNT_PASSWORD = '<PASSWORD>'
+
+# BRAND can be one of the following:
+# liftmaster
+# chamberlain
+# craftsmaster
+# merlin
+MYQ_BRAND = '<BRAND>'
+LOGLEVEL = 'ERROR'
 
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
+
+    loglevels = dict((logging.getLevelName(level), level)
+                     for level in [10, 20, 30, 40, 50])
+
+    logging.basicConfig(
+        level=loglevels[LOGLEVEL],
+        format='%(asctime)s:%(levelname)s:\t%(name)s\t%(message)s')
+
     async with ClientSession() as websession:
         try:
             myq = await pymyq.login(
-                '<EMAIL>', '<PASSWORD>', '<BRAND>', websession)
+                MYQ_ACCOUNT_EMAIL, MYQ_ACCOUNT_PASSWORD, MYQ_BRAND, websession)
 
             devices = await myq.get_devices()
             for idx, device in enumerate(devices):
@@ -23,15 +45,44 @@ async def main() -> None:
                 print('Serial: {0}'.format(device.serial))
                 print('Device ID: {0}'.format(device.device_id))
                 print('Parent ID: {0}'.format(device.parent_id))
-                print('Current State: {0}'.format(device.state))
+                print('Online: {0}'.format(device.available))
+                print('Unattended Open: {0}'.format(device.open_allowed))
+                print('Unattended Close: {0}'.format(device.close_allowed))
                 print()
-                print('Opening the device...')
-                await device.open()
                 print('Current State: {0}'.format(device.state))
-                await asyncio.sleep(15)
-                print('Closing the device...')
-                await device.close()
-                print('Current State: {0}'.format(device.state))
+                if device.state != STATE_OPEN:
+                    print('Opening the device...')
+                    await device.open()
+                    print('    0 Current State: {0}'.format(device.state))
+                    for waited in range(1, 30):
+                        if device.state == STATE_OPEN:
+                            break
+                        await asyncio.sleep(1)
+                        await device.update()
+                        print('    {} Current State: {}'.format(
+                            waited, device.state))
+
+                    await asyncio.sleep(10)
+                    await device.update()
+                    print()
+                    print('Current State: {0}'.format(device.state))
+
+                if device.state != STATE_CLOSED:
+                    print('Closing the device...')
+                    await device.close()
+                    print('    0 Current State: {0}'.format(device.state))
+                    for waited in range(1, 30):
+                        if device.state == STATE_CLOSED:
+                            break
+                        await asyncio.sleep(1)
+                        await device.update()
+                        print('    {} Current State: {}'.format(
+                            waited, device.state))
+
+                    await asyncio.sleep(10)
+                    await device.update()
+                    print()
+                    print('Current State: {0}'.format(device.state))
         except MyQError as err:
             print(err)
 

--- a/pymyq/__version__.py
+++ b/pymyq/__version__.py
@@ -1,2 +1,2 @@
 """Define a version constant."""
-__version__ = '1.0.0'
+__version__ = '1.1.0'

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -1,7 +1,9 @@
 """Define the MyQ API."""
+import asyncio
 import logging
+from datetime import datetime, timedelta
 
-from aiohttp import BasicAuth, ClientSession
+from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
 
 from .device import MyQDevice
@@ -14,6 +16,10 @@ LOGIN_ENDPOINT = "api/v4/User/Validate"
 DEVICE_LIST_ENDPOINT = "api/v4/UserDeviceDetails/Get"
 
 DEFAULT_TIMEOUT = 10
+DEFAULT_UPDATE_RETRIES = 3
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=DEFAULT_TIMEOUT)
+
 DEFAULT_USER_AGENT = "Chamberlain/3773 (iPhone; iOS 11.0.3; Scale/2.00)"
 
 BRAND_MAPPINGS = {
@@ -53,7 +59,11 @@ class API:
 
         self._brand = brand
         self._security_token = None
+        self._devices = []
+        self._last_update = None
         self._websession = websession
+        self._update_lock = asyncio.Lock()
+        self._request_lock = asyncio.Lock()
 
     async def _request(
             self,
@@ -77,18 +87,64 @@ class API:
             'User-Agent': DEFAULT_USER_AGENT,
         })
 
+        _LOGGER.debug('Initiating request to %s', url)
+        async with self._request_lock:
+            for attempt in range(0, DEFAULT_UPDATE_RETRIES - 1):
+                try:
+                    async with self._websession.request(
+                            method, url, headers=headers, params=params,
+                            data=data, json=json, timeout=DEFAULT_TIMEOUT,
+                            **kwargs) as resp:
+                        resp.raise_for_status()
+                        return await resp.json(content_type=None)
+                except (asyncio.TimeoutError, ClientError) as err:
+                    if attempt == DEFAULT_UPDATE_RETRIES - 1:
+                        raise RequestError(
+                            'Error requesting data from {0}: {1}'.format(
+                                endpoint, err))
+                    _LOGGER.error('Request for %s failed; retrying. %s',
+                                  endpoint, err)
+                    await asyncio.sleep(5)
+        _LOGGER.debug('Request to %s completed', url)
+
+    async def _update_device_state(self):
+        async with self._update_lock:
+            if datetime.utcnow() - self._last_update >\
+                    MIN_TIME_BETWEEN_UPDATES:
+                await self._get_device_states()
+
+    async def _get_device_states(self):
+        _LOGGER.debug('Retrieving new device states')
         try:
-            async with self._websession.request(
-                    method, url, headers=headers, params=params, data=data,
-                    json=json, timeout=DEFAULT_TIMEOUT, **kwargs) as resp:
-                resp.raise_for_status()
-                return await resp.json(content_type=None)
-        except ClientError as err:
-            raise RequestError(
-                'Error requesting data from {0}: {1}'.format(endpoint, err))
+            devices_resp = await self._request('get', DEVICE_LIST_ENDPOINT)
+        except RequestError as err:
+            _LOGGER.error('Getting device states failed: %s', err)
+            return False
+
+        if int(devices_resp.get('ReturnCode', 1)) != 0:
+            _LOGGER.error(
+                'Error while retrieving states: %s',
+                devices_resp.get('ErrorMessage', 'Unknown Error'))
+            return False
+
+        self._store_device_states(devices_resp.get('Devices', []))
+        _LOGGER.debug('New device states retrieved')
+
+    def _store_device_states(self, devices):
+        for device in self._devices:
+            myq_device = next(
+                (element for element in devices
+                 if element.get('MyQDeviceId') == device['device_id']), None)
+
+            if myq_device is not None:
+                device['device_info'] = myq_device
+                continue
+
+        self._last_update = datetime.utcnow()
 
     async def authenticate(self, username: str, password: str) -> None:
         """Authenticate against the API."""
+        _LOGGER.debug('Starting authentication')
         login_resp = await self._request(
             'post',
             LOGIN_ENDPOINT,
@@ -101,15 +157,32 @@ class API:
             raise MyQError(login_resp['ErrorMessage'])
 
         self._security_token = login_resp['SecurityToken']
+        _LOGGER.debug('Authentication completed')
 
     async def get_devices(self, covers_only: bool = True) -> list:
         """Get a list of all devices associated with the account."""
+        _LOGGER.debug('Retrieving list of devices')
         devices_resp = await self._request('get', DEVICE_LIST_ENDPOINT)
-        return [
-            MyQDevice(device, self._brand, self._request)
-            for device in devices_resp['Devices'] if not covers_only
-            or device['MyQDeviceTypeName'] in SUPPORTED_DEVICE_TYPE_NAMES
-        ]
+        # print(json.dumps(devices_resp, indent=4))
+
+        device_list = []
+        for device in devices_resp['Devices']:
+            if not covers_only or \
+               device['MyQDeviceTypeName'] in SUPPORTED_DEVICE_TYPE_NAMES:
+
+                self._devices.append({
+                    'device_id': device['MyQDeviceId'],
+                    'device_info': device
+                })
+                myq_device = MyQDevice(
+                    self._devices[-1], self._brand, self)
+                device_list.append(myq_device)
+
+        # Store current device states.
+        self._store_device_states(devices_resp.get('Devices', []))
+
+        _LOGGER.debug('List of devices retrieved')
+        return device_list
 
 
 async def login(

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -98,13 +98,20 @@ class API:
                         resp.raise_for_status()
                         return await resp.json(content_type=None)
                 except (asyncio.TimeoutError, ClientError) as err:
+                    if isinstance(err, ClientError):
+                        type_exception = 'ClientError'
+                    else:
+                        type_exception = 'TimeOut'
+
                     if attempt == DEFAULT_UPDATE_RETRIES - 1:
                         raise RequestError(
-                            'Error requesting data from {0}: {1}'.format(
-                                endpoint, err))
-                    _LOGGER.error('Request for %s failed; retrying. %s',
-                                  endpoint, err)
+                            '{} requesting data from {}: {}'.format(
+                                type_exception, endpoint, err))
+
+                    _LOGGER.warning('%s for %s; retrying: %s',
+                                  type_exception, endpoint, err)
                     await asyncio.sleep(5)
+
         _LOGGER.debug('Request to %s completed', url)
 
     async def _update_device_state(self):

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Union
 
+from .api import API
 from .errors import RequestError
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ STATE_MAP = {
 class MyQDevice:
     """Define a generic MyQ device."""
 
-    def __init__(self, device: dict, brand: str, api) -> None:
+    def __init__(self, device: dict, brand: str, api: API) -> None:
         """Initialize."""
         self._brand = brand
         self._device = device

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -i https://pypi.python.org/simple
 aiodns==1.1.1
-aiohttp==3.4.4
-async-timeout==3.0.1
+aiohttp>=3.4
+async_timeout>=3.0.1
 attrs==18.2.0
 chardet==3.0.4
 idna==2.7


### PR DESCRIPTION
Retrieving device states (open, close) from MyQ are now done through 1 request and stored internally. Through each device an update can still be requested however retrieval from the MyQ cloud is restricted to once every 5 seconds.

Requests to the MyQ cloud will also be sent synchronously ensuring only 1 request can be sent at a time.

These changes are to minimize requests to MyQ as there definitely seems to be a throttler on their end for how many requests can come in per account or so.

Note, just put this together today. Working here but would be good if we can get some more people involved to test these updates.