### PR TITLE
Change websession to optional parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ pymyq.egg-info
 .DS_Store
 .idea/
 __pycache__/
-venv/
+venv*/
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ All of the routines on the `MyQDevice` class are coroutines and need to be
 * `open`: open the device
 * `update`: get the latest device state (which can then be accessed via the 
 `state` property). Retrieval of state from cloud is will only be done if more then 5 seconds has elapsed since last 
-request. State for all devices is retrieved through (1) request.  
+request. State for all devices is retrieved through (1) request.
+* `close_connection`: close web session connection, will only close the web session if none was provided initially  
 
 # Disclaimer
 

--- a/pymyq/__version__.py
+++ b/pymyq/__version__.py
@@ -1,2 +1,2 @@
 """Define a version constant."""
-__version__ = '1.2.0'
+__version__ = '1.2.0b1'

--- a/pymyq/__version__.py
+++ b/pymyq/__version__.py
@@ -1,2 +1,2 @@
 """Define a version constant."""
-__version__ = '1.2.0b1'
+__version__ = '1.2.0'

--- a/pymyq/__version__.py
+++ b/pymyq/__version__.py
@@ -1,2 +1,2 @@
 """Define a version constant."""
-__version__ = '1.1.0'
+__version__ = '1.2.0'

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -101,6 +101,7 @@ class API:
         self._websession = None
         await temp_websession.close()
         await asyncio.sleep(0)
+        _LOGGER.debug('Connections closed')
 
     async def _request(
             self,

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -206,3 +206,7 @@ class MyQDevice:
         self.next_allowed_update = None
         await self.api._update_device_state()
         self._device_json = self._device['device_info']
+
+    async def close_connection(self):
+        """Close the web session connection with MyQ"""
+        await self.api.close_websession()


### PR DESCRIPTION
websession is now an optional parameter. If not provided then a websession will be created upon 1st request automatically.
 
A new method close_connection is introduced as well to close the created websession. This method will only close the connection if the session was created by pymyq. 
