### PR TITLE
Update library to work with API version 5

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ import pymyq
 async def main() -> None:
     """Create the aiohttp session and run."""
     async with ClientSession() as websession:
-      # Valid Brands: 'chamberlain', 'craftsman', 'liftmaster', 'merlin'
-      myq = await pymyq.login('<EMAIL>', '<PASSWORD>', '<BRAND>', websession)
+      myq = await pymyq.login('<EMAIL>', '<PASSWORD>', websession)
 
       # Return only cover devices:
       devices = myq.covers

--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ async def main() -> None:
       myq = await pymyq.login('<EMAIL>', '<PASSWORD>', '<BRAND>', websession)
 
       # Return only cover devices:
-      devices = await myq.get_devices()
+      devices = myq.covers
+      # >>> {"serial_number123": <Device>}
 
       # Return *all* devices:
-      devices = await myq.get_devices(covers_only=False)
+      devices = myq.devices
+      # >>> {"serial_number123": <Device>, "serial_number456": <Device>}
 
 
 asyncio.get_event_loop().run_until_complete(main())
@@ -60,28 +62,26 @@ asyncio.get_event_loop().run_until_complete(main())
 
 ## Device Properties
 
-* `brand`: the brand of the device
-* `device_id`: the device's MyQ ID
-* `parent_id`: the device's parent device's MyQ ID
-* `name`: the name of the device
-* `available`: if device is online
-* `serial`: the serial number of the device
-* `state`: the device's current state
-* `type`: the type of MyQ device
-* `open_allowed`: if device can be opened unattended
-* `close_allowed`: if device can be closed unattended
+`close_allowed`: Return whether the device can be closed unattended.
+`device_family`: Return the family in which this device lives.
+`device_id`: Return the device ID (serial number).
+`device_platform`: Return the device platform.
+`device_type`: Return the device type.
+`firmware_version`: Return the family in which this device lives.
+`name`: Return the device name.
+`online`: Return whether the device is online.
+`open_allowed`: Return whether the device can be opened unattended.
+`parent_device_id`: Return the device ID (serial number) of this device's parent.
+`state`: Return the current state of the device.
 
 ## Methods
 
 All of the routines on the `MyQDevice` class are coroutines and need to be
-`await`ed.
+`await`ed – see `example.py` for examples.
 
 * `close`: close the device
 * `open`: open the device
-* `update`: get the latest device state (which can then be accessed via the 
-`state` property). Retrieval of state from cloud is will only be done if more then 5 seconds has elapsed since last 
-request. State for all devices is retrieved through (1) request.
-* `close_connection`: close web session connection, will only close the web session if none was provided initially  
+* `update`: get the latest device info (state, etc.)
 
 # Disclaimer
 

--- a/example.py
+++ b/example.py
@@ -12,13 +12,6 @@ _LOGGER = logging.getLogger()
 EMAIL = "<EMAIL>"
 PASSWORD = "<PASSWORD>"
 
-# BRAND can be one of the following:
-# liftmaster
-# chamberlain
-# craftsmaster
-# merlin
-BRAND = "chamberlain"
-
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
@@ -26,7 +19,7 @@ async def main() -> None:
     async with ClientSession() as websession:
         try:
             # Create an API object:
-            api = await login(EMAIL, PASSWORD, BRAND, websession)
+            api = await login(EMAIL, PASSWORD, websession)
 
             # Get the account ID:
             _LOGGER.info("Account ID: %s", api.account_id)

--- a/example.py
+++ b/example.py
@@ -1,100 +1,35 @@
-"""Run an example script to quickly test any MyQ account."""
+"""Run an example script to quickly test."""
 import asyncio
 import logging
-import json
 
 from aiohttp import ClientSession
 
-import pymyq
-from pymyq.device import STATE_CLOSED, STATE_OPEN
+from pymyq import login
 from pymyq.errors import MyQError
 
-# Provide your email and password account details for MyQ.
-MYQ_ACCOUNT_EMAIL = '<EMAIL>'
-MYQ_ACCOUNT_PASSWORD = '<PASSWORD>'
+_LOGGER = logging.getLogger()
 
-# BRAND can be one of the following:
-# liftmaster
-# chamberlain
-# craftsmaster
-# merlin
-MYQ_BRAND = '<BRAND>'
-LOGLEVEL = 'ERROR'
-
-# Set JSON_DUMP to True to dump all the device information retrieved,
-# this can be helpful to determine what else is available.
-# Set JSON_DUMP to False to open/close the doors instead. i.e.:
-# JSON_DUMP = False
-JSON_DUMP = True
+EMAIL = "<EMAIL ADDRESS>"
+PASSWORD = "<PASSWORD>"
+BRAND = "chamberlain"
 
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-
-    loglevels = dict((logging.getLevelName(level), level)
-                     for level in [10, 20, 30, 40, 50])
-
-    logging.basicConfig(
-        level=loglevels[LOGLEVEL],
-        format='%(asctime)s:%(levelname)s:\t%(name)s\t%(message)s')
-
+    logging.basicConfig(level=logging.INFO)
     async with ClientSession() as websession:
         try:
-            myq = await pymyq.login(
-                MYQ_ACCOUNT_EMAIL, MYQ_ACCOUNT_PASSWORD, MYQ_BRAND, websession)
+            # Create an API object:
+            api = await login(EMAIL, PASSWORD, BRAND, websession)
 
-            devices = await myq.get_devices()
-            for idx, device in enumerate(devices):
-                print('Device #{0}: {1}'.format(idx + 1, device.name))
-                print('--------')
-                print('Brand: {0}'.format(device.brand))
-                print('Type: {0}'.format(device.type))
-                print('Serial: {0}'.format(device.serial))
-                print('Device ID: {0}'.format(device.device_id))
-                print('Parent ID: {0}'.format(device.parent_id))
-                print('Online: {0}'.format(device.available))
-                print('Unattended Open: {0}'.format(device.open_allowed))
-                print('Unattended Close: {0}'.format(device.close_allowed))
-                print()
-                print('Current State: {0}'.format(device.state))
-                if JSON_DUMP:
-                    print(json.dumps(device._device, indent=4))
-                else:
-                    if device.state != STATE_OPEN:
-                        print('Opening the device...')
-                        await device.open()
-                        print('    0 Current State: {0}'.format(device.state))
-                        for waited in range(1, 30):
-                            if device.state == STATE_OPEN:
-                                break
-                            await asyncio.sleep(1)
-                            await device.update()
-                            print('    {} Current State: {}'.format(
-                                waited, device.state))
+            # Get the account ID:
+            _LOGGER.info("Account ID: %s", api.account_id)
 
-                        await asyncio.sleep(10)
-                        await device.update()
-                        print()
-                        print('Current State: {0}'.format(device.state))
-
-                    if device.state != STATE_CLOSED:
-                        print('Closing the device...')
-                        await device.close()
-                        print('    0 Current State: {0}'.format(device.state))
-                        for waited in range(1, 30):
-                            if device.state == STATE_CLOSED:
-                                break
-                            await asyncio.sleep(1)
-                            await device.update()
-                            print('    {} Current State: {}'.format(
-                                waited, device.state))
-
-                        await asyncio.sleep(10)
-                        await device.update()
-                        print()
-                        print('Current State: {0}'.format(device.state))
+            # Get all devices listed with this account:
+            for cover in api.covers.values():
+                await cover.open()
         except MyQError as err:
-            print(err)
+            _LOGGER.error("There was an error: %s", err)
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/example.py
+++ b/example.py
@@ -5,12 +5,18 @@ import logging
 from aiohttp import ClientSession
 
 from pymyq import login
-from pymyq.errors import MyQError
+from pymyq.errors import MyQError, RequestError
 
 _LOGGER = logging.getLogger()
 
-EMAIL = "<EMAIL ADDRESS>"
+EMAIL = "<EMAIL>"
 PASSWORD = "<PASSWORD>"
+
+# BRAND can be one of the following:
+# liftmaster
+# chamberlain
+# craftsmaster
+# merlin
 BRAND = "chamberlain"
 
 
@@ -25,9 +31,29 @@ async def main() -> None:
             # Get the account ID:
             _LOGGER.info("Account ID: %s", api.account_id)
 
-            # Get all devices listed with this account:
-            for cover in api.covers.values():
-                await cover.open()
+            # Get all devices listed with this account – note that you can use
+            # api.covers to only examine covers:
+            for idx, device_id in enumerate(api.devices):
+                device = api.devices[device_id]
+                _LOGGER.info("---------")
+                _LOGGER.info("Device %s: %s", idx + 1, device.name)
+                _LOGGER.info("Device Online: %s", device.online)
+                _LOGGER.info("Device ID: %s", device.device_id)
+                _LOGGER.info("Parent Device ID: %s", device.parent_device_id)
+                _LOGGER.info("Device Family: %s", device.device_family)
+                _LOGGER.info("Device Platform: %s", device.device_platform)
+                _LOGGER.info("Device Type: %s", device.device_type)
+                _LOGGER.info("Firmware Version: %s", device.firmware_version)
+                _LOGGER.info("Open Allowed: %s", device.open_allowed)
+                _LOGGER.info("Close Allowed: %s", device.close_allowed)
+                _LOGGER.info("Current State: %s", device.state)
+
+                try:
+                    await device.open()
+                    await asyncio.sleep(15)
+                    await device.close()
+                except RequestError as err:
+                    _LOGGER.error(err)
         except MyQError as err:
             _LOGGER.error("There was an error: %s", err)
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,14 @@
+[MESSAGES CONTROL]
+# Reasons disabled:
+# bad-continuation - Invalid attack on black
+# unnecessary-pass - This can hurt readability
+disable=
+  bad-continuation,
+  unnecessary-pass
+
+[REPORTS]
+reports=no
+
+[FORMAT]
+expected-line-ending-format=LF
+

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -5,7 +5,7 @@ from typing import Dict
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
 
-from .device import Device
+from .device import MyQDevice
 from .errors import RequestError, SecurityTokenError, UnsupportedBrandError
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         self._security_token = None
         self._username = None
         self._websession = websession
-        self.devices = {}  # type: Dict[str, Device]
+        self.devices = {}  # type: Dict[str, MyQDevice]
 
     @property
     def account_id(self) -> str:
@@ -54,7 +54,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         return self._account_info["Account"]["Id"]
 
     @property
-    def covers(self) -> Dict[str, Device]:
+    def covers(self) -> Dict[str, MyQDevice]:
         """Return only those devices that are covers."""
         return {
             device_id: device
@@ -142,7 +142,7 @@ class API:  # pylint: disable=too-many-instance-attributes
     async def update_device_info(self) -> dict:
         """Get up-to-date device info."""
         devices_resp = await self.request(
-            "get", "Accounts/{0}/Devices".format(self.account_id)
+            "get", "Accounts/{0}/MyQDevices".format(self.account_id)
         )
 
         for device_json in devices_resp["items"]:
@@ -151,7 +151,9 @@ class API:  # pylint: disable=too-many-instance-attributes
                 device = self.devices[serial_number]
                 device.device_json = device_json
             else:
-                self.devices[device_json["serial_number"]] = Device(self, device_json)
+                self.devices[device_json["serial_number"]] = MyQDevice(
+                    self, device_json
+                )
 
 
 async def login(

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -9,7 +9,6 @@ from .device import MyQDevice
 from .errors import (
     InvalidCredentialsError,
     RequestError,
-    SecurityTokenError,
     UnsupportedBrandError,
 )
 
@@ -107,8 +106,8 @@ class API:  # pylint: disable=too-many-instance-attributes
                     if login_request:
                         raise InvalidCredentialsError("Invalid username/password")
                     if self._retry_security_token:
-                        raise SecurityTokenError(
-                            "Couldn't retrieve valid security token after several tries"
+                        raise RequestError(
+                            "Couldn't retrieve valid security token after two tries"
                         )
 
                     _LOGGER.info("401 detected; attempting to get a new security token")

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -15,6 +15,8 @@ API_BASE = "https://api.myqdevice.com/api/v{0}".format(API_VERSION)
 
 DEFAULT_USER_AGENT = "Chamberlain/3.73"
 
+NON_COVER_DEVICE_FAMILIES = ("gateway")
+
 BRAND_MAPPINGS = {
     "liftmaster": {
         "app_id": "NWknvuBd7LoFHfXmKNMBcgajXtZEgKUh4V7WNzMidrpUUluDpVYVZx+xT4PCM5Kx"
@@ -59,7 +61,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         return {
             device_id: device
             for device_id, device in self.devices.items()
-            if device.device_json["device_family"] != "gateway"
+            if device.device_json["device_family"] not in NON_COVER_DEVICE_FAMILIES
         }
 
     async def request(
@@ -142,7 +144,7 @@ class API:  # pylint: disable=too-many-instance-attributes
     async def update_device_info(self) -> dict:
         """Get up-to-date device info."""
         devices_resp = await self.request(
-            "get", "Accounts/{0}/MyQDevices".format(self.account_id)
+            "get", "Accounts/{0}/Devices".format(self.account_id)
         )
 
         for device_json in devices_resp["items"]:

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -162,9 +162,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         self._last_state_update = datetime.utcnow()
 
 
-async def login(
-    username: str, password: str, websession: ClientSession = None
-) -> API:
+async def login(username: str, password: str, websession: ClientSession = None) -> API:
     """Log in to the API."""
     api = API(websession)
     await api.authenticate(username, password)

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -65,22 +65,15 @@ class API:  # pylint: disable=too-many-instance-attributes
     async def request(
         self,
         method: str,
+        endpoint: str,
         *,
-        endpoint: str = None,
-        full_url: str = None,
         headers: dict = None,
         params: dict = None,
         json: dict = None,
         **kwargs
     ) -> dict:
         """Make a request."""
-        if endpoint and full_url:
-            raise RequestError("You can't specify both endpoint and full_url")
-
-        if full_url:
-            url = full_url
-        else:
-            url = "{0}/{1}".format(API_BASE, endpoint)
+        url = "{0}/{1}".format(API_BASE, endpoint)
 
         if not headers:
             headers = {}
@@ -133,14 +126,14 @@ class API:  # pylint: disable=too-many-instance-attributes
 
         # Retrieve and store the initial security token:
         auth_resp = await self.request(
-            "post", endpoint="Login", json={"Username": username, "Password": password}
+            "post", "Login", json={"Username": username, "Password": password}
         )
         self._security_token = auth_resp["SecurityToken"]
         self._retry_security_token = False
 
         # Retrieve and store account info:
         self._account_info = await self.request(
-            "get", endpoint="My", params={"expand": "account"}
+            "get", "My", params={"expand": "account"}
         )
 
         # Retrieve and store initial set of devices:
@@ -149,7 +142,7 @@ class API:  # pylint: disable=too-many-instance-attributes
     async def update_device_info(self) -> dict:
         """Get up-to-date device info."""
         devices_resp = await self.request(
-            "get", endpoint="Accounts/{0}/Devices".format(self.account_id)
+            "get", "Accounts/{0}/Devices".format(self.account_id)
         )
 
         for device_json in devices_resp["items"]:

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -8,45 +8,27 @@ from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
 
 from .device import MyQDevice
-from .errors import InvalidCredentialsError, RequestError, UnsupportedBrandError
+from .errors import InvalidCredentialsError, RequestError
 
 _LOGGER = logging.getLogger(__name__)
 
 API_VERSION = 5
 API_BASE = "https://api.myqdevice.com/api/v{0}".format(API_VERSION)
 
+DEFAULT_APP_ID = "JVM/G9Nwih5BwKgNCjLxiFUQxQijAebyyg8QUHr7JOrP+tuPb8iHfRHKwTmDzHOu"
 DEFAULT_REQUEST_RETRIES = 3
 DEFAULT_STATE_UPDATE_INTERVAL = timedelta(seconds=5)
 DEFAULT_USER_AGENT = "Chamberlain/3.73"
 
 NON_COVER_DEVICE_FAMILIES = "gateway"
 
-BRAND_MAPPINGS = {
-    "liftmaster": {
-        "app_id": "JVM/G9Nwih5BwKgNCjLxiFUQxQijAebyyg8QUHr7JOrP+tuPb8iHfRHKwTmDzHOu"
-    },
-    "chamberlain": {
-        "app_id": "JVM/G9Nwih5BwKgNCjLxiFUQxQijAebyyg8QUHr7JOrP+tuPb8iHfRHKwTmDzHOu"
-    },
-    "craftsman": {
-        "app_id": "JVM/G9Nwih5BwKgNCjLxiFUQxQijAebyyg8QUHr7JOrP+tuPb8iHfRHKwTmDzHOu"
-    },
-    "merlin": {
-        "app_id": "JVM/G9Nwih5BwKgNCjLxiFUQxQijAebyyg8QUHr7JOrP+tuPb8iHfRHKwTmDzHOu"
-    },
-}
-
 
 class API:  # pylint: disable=too-many-instance-attributes
     """Define a class for interacting with the MyQ iOS App API."""
 
-    def __init__(self, brand: str, websession: ClientSession = None) -> None:
+    def __init__(self, websession: ClientSession = None) -> None:
         """Initialize."""
-        if brand not in BRAND_MAPPINGS:
-            raise UnsupportedBrandError("Unknown brand: {0}".format(brand))
-
         self._account_info = {}
-        self._brand = brand
         self._last_state_update = None  # type: Optional[datetime]
         self._lock = asyncio.Lock()
         self._password = None
@@ -90,7 +72,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         headers.update(
             {
                 "Content-Type": "application/json",
-                "MyQApplicationId": BRAND_MAPPINGS[self._brand]["app_id"],
+                "MyQApplicationId": DEFAULT_APP_ID,
                 "User-Agent": DEFAULT_USER_AGENT,
             }
         )
@@ -181,9 +163,9 @@ class API:  # pylint: disable=too-many-instance-attributes
 
 
 async def login(
-    username: str, password: str, brand: str, websession: ClientSession = None
+    username: str, password: str, websession: ClientSession = None
 ) -> API:
     """Log in to the API."""
-    api = API(brand, websession)
+    api = API(websession)
     await api.authenticate(username, password)
     return api

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -31,9 +31,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         self._account_info = {}
         self._last_state_update = None  # type: Optional[datetime]
         self._lock = asyncio.Lock()
-        self._password = None
-        self._security_token = None
-        self._username = None
+        self._security_token = None  # type: Optional[str]
         self._websession = websession
         self.devices = {}  # type: Dict[str, MyQDevice]
 
@@ -112,9 +110,6 @@ class API:  # pylint: disable=too-many-instance-attributes
 
     async def authenticate(self, username: str, password: str) -> None:
         """Authenticate and get a security token."""
-        self._username = username
-        self._password = password
-
         # Retrieve and store the initial security token:
         auth_resp = await self.request(
             "post",

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -87,11 +87,10 @@ class API:  # pylint: disable=too-many-instance-attributes
                         resp.raise_for_status()
                         return data
                     except ClientError as err:
-                        if "401" in str(err):
-                            if login_request:
-                                raise InvalidCredentialsError(
-                                    "Invalid username/password"
-                                )
+                        if "401" in str(err) and login_request:
+                            raise InvalidCredentialsError(
+                                "Invalid username/password"
+                            )
 
                         if attempt == DEFAULT_REQUEST_RETRIES - 1:
                             raise RequestError(

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -16,7 +16,7 @@ API_VERSION = 5
 API_BASE = "https://api.myqdevice.com/api/v{0}".format(API_VERSION)
 
 DEFAULT_APP_ID = "JVM/G9Nwih5BwKgNCjLxiFUQxQijAebyyg8QUHr7JOrP+tuPb8iHfRHKwTmDzHOu"
-DEFAULT_REQUEST_RETRIES = 3
+DEFAULT_REQUEST_RETRIES = 5
 DEFAULT_STATE_UPDATE_INTERVAL = timedelta(seconds=5)
 DEFAULT_USER_AGENT = "Chamberlain/3.73"
 
@@ -100,7 +100,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                                 )
                             )
 
-                        wait_for = 2 ** attempt
+                        wait_for = min(2 ** attempt, 5)
 
                         _LOGGER.warning(
                             "Device update failed; trying again in %s seconds", wait_for

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -1,293 +1,169 @@
 """Define the MyQ API."""
-import asyncio
 import logging
-from datetime import datetime, timedelta
-from typing import Optional
+from typing import Dict
 
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
 
-from .errors import MyQError, RequestError, UnsupportedBrandError
+from .device import Device
+from .errors import RequestError, SecurityTokenError, UnsupportedBrandError
 
 _LOGGER = logging.getLogger(__name__)
 
-API_BASE = 'https://myqexternal.myqdevice.com'
-LOGIN_ENDPOINT = "api/v4/User/Validate"
-DEVICE_LIST_ENDPOINT = "api/v4/UserDeviceDetails/Get"
-
-DEFAULT_TIMEOUT = 1
-DEFAULT_REQUEST_RETRIES = 3
-
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
+API_VERSION = 5
+API_BASE = "https://api.myqdevice.com/api/v{0}".format(API_VERSION)
 
 DEFAULT_USER_AGENT = "Chamberlain/3.73"
 
 BRAND_MAPPINGS = {
-    'liftmaster': {
-        'app_id':
-        # 'Vj8pQggXLhLy0WHahglCD4N1nAkkXQtGYpq2HrHD7H1nvmbT55KqtN6RSF4ILB/i'
-            'NWknvuBd7LoFHfXmKNMBcgajXtZEgKUh4V7WNzMidrpUUluDpVYVZx+xT4PCM5Kx'
+    "liftmaster": {
+        "app_id": "NWknvuBd7LoFHfXmKNMBcgajXtZEgKUh4V7WNzMidrpUUluDpVYVZx+xT4PCM5Kx"
     },
-    'chamberlain': {
-        'app_id':
-            'OA9I/hgmPHFp9RYKJqCKfwnhh28uqLJzZ9KOJf1DXoo8N2XAaVX6A1wcLYyWsnnv'
+    "chamberlain": {
+        "app_id": "OA9I/hgmPHFp9RYKJqCKfwnhh28uqLJzZ9KOJf1DXoo8N2XAaVX6A1wcLYyWsnnv"
     },
-    'craftsman': {
-        'app_id':
-        # 'YmiMRRS1juXdSd0KWsuKtHmQvh5RftEp5iewHdCvsNB77FnQbY+vjCVn2nMdIeN8'
-            'eU97d99kMG4t3STJZO/Mu2wt69yTQwM0WXZA5oZ74/ascQ2xQrLD/yjeVhEQccBZ'
+    "craftsman": {
+        "app_id": "eU97d99kMG4t3STJZO/Mu2wt69yTQwM0WXZA5oZ74/ascQ2xQrLD/yjeVhEQccBZ"
     },
-    'merlin': {
-        'app_id':
-            '3004cac4e920426c823fa6c2ecf0cc28ef7d4a7b74b6470f8f0d94d6c39eb718'
-    }
+    "merlin": {
+        "app_id": "3004cac4e920426c823fa6c2ecf0cc28ef7d4a7b74b6470f8f0d94d6c39eb718"
+    },
 }
 
-SUPPORTED_DEVICE_TYPE_NAMES = [
-    'Garage Door Opener WGDO',
-    'GarageDoorOpener',
-    'Gate',
-    'VGDO',
-]
 
-
-class API:
+class API:  # pylint: disable=too-many-instance-attributes
     """Define a class for interacting with the MyQ iOS App API."""
 
     def __init__(self, brand: str, websession: ClientSession = None) -> None:
-        """Initialize the API object."""
+        """Initialize."""
         if brand not in BRAND_MAPPINGS:
-            raise UnsupportedBrandError('Unknown brand: {0}'.format(brand))
+            raise UnsupportedBrandError("Unknown brand: {0}".format(brand))
 
+        self._account_info = {}
         self._brand = brand
-        self._websession = websession
-        self._supplied_websession = True
-
-        self._credentials = None
+        self._password = None
+        self._retry_security_token = False
         self._security_token = None
-        self._devices = []
-        self._last_update = None
-        self.online = False
+        self._username = None
+        self._websession = websession
+        self.devices = {}  # type: Dict[str, Device]
 
-        self._update_lock = asyncio.Lock()
-        self._security_token_lock = asyncio.Lock()
+    @property
+    def account_id(self) -> str:
+        """Return the account ID."""
+        return self._account_info["Account"]["Id"]
 
-    def _create_websession(self):
-        """Create a web session."""
-        from socket import AF_INET
-        from aiohttp import ClientTimeout, TCPConnector
+    @property
+    def covers(self) -> Dict[str, Device]:
+        """Return only those devices that are covers."""
+        return {
+            device_id: device
+            for device_id, device in self.devices.items()
+            if device.device_json["device_family"] != "gateway"
+        }
 
-        _LOGGER.debug('Creating web session')
-        conn = TCPConnector(
-            family=AF_INET,
-            limit_per_host=5,
-            enable_cleanup_closed=True,
-        )
+    async def request(
+        self,
+        method: str,
+        *,
+        endpoint: str = None,
+        full_url: str = None,
+        headers: dict = None,
+        params: dict = None,
+        json: dict = None,
+        **kwargs
+    ) -> dict:
+        """Make a request."""
+        if endpoint and full_url:
+            raise RequestError("You can't specify both endpoint and full_url")
 
-        # Create session object.
-        session_timeout = ClientTimeout(connect=10)
-        self._websession = ClientSession(connector=conn,
-                                         timeout=session_timeout)
-        self._supplied_websession = False
-
-    async def close_websession(self):
-        """Close web session if not already closed and created by us."""
-        # We do not close the web session if it was provided.
-        if self._supplied_websession or self._websession is None:
-            return
-
-        _LOGGER.debug('Closing connections')
-        # Need to set _websession to none first to prevent any other task
-        # from closing it as well.
-        temp_websession = self._websession
-        self._websession = None
-        await temp_websession.close()
-        await asyncio.sleep(0)
-        _LOGGER.debug('Connections closed')
-
-    async def _request(
-            self,
-            method: str,
-            endpoint: str,
-            *,
-            headers: dict = None,
-            params: dict = None,
-            data: dict = None,
-            json: dict = None,
-            login_request: bool = False,
-            **kwargs) -> Optional[dict]:
-
-        # Get a security token if we do not have one AND this request
-        # is not to get a security token.
-        if self._security_token is None and not login_request:
-            await self._get_security_token()
-            if self._security_token is None:
-                return None
-
-        url = '{0}/{1}'.format(API_BASE, endpoint)
+        if full_url:
+            url = full_url
+        else:
+            url = "{0}/{1}".format(API_BASE, endpoint)
 
         if not headers:
             headers = {}
         if self._security_token:
-            headers['SecurityToken'] = self._security_token
-        headers.update({
-            'MyQApplicationId': BRAND_MAPPINGS[self._brand]['app_id'],
-            'User-Agent': DEFAULT_USER_AGENT,
-        })
+            headers["SecurityToken"] = self._security_token
+        headers.update(
+            {
+                "Content-Type": "application/json",
+                "MyQApplicationId": BRAND_MAPPINGS[self._brand]["app_id"],
+                "User-Agent": DEFAULT_USER_AGENT,
+            }
+        )
 
-        # Create the web session if none exist.
-        if self._websession is None:
-            self._create_websession()
-
-        start_request_time = datetime.time(datetime.now())
-        _LOGGER.debug('%s Initiating request to %s', start_request_time, url)
-        timeout = DEFAULT_TIMEOUT
-        # Repeat twice amount of max requests retries for timeout errors.
-        for attempt in range(0, (DEFAULT_REQUEST_RETRIES * 2) - 1):
+        async with self._websession.request(
+            method, url, headers=headers, params=params, json=json, **kwargs
+        ) as resp:
+            data = await resp.json(content_type=None)
             try:
-                async with self._websession.request(
-                        method, url, headers=headers, params=params,
-                        data=data, json=json, timeout=timeout,
-                        **kwargs) as resp:
-                    resp.raise_for_status()
-                    return await resp.json(content_type=None)
-            except asyncio.TimeoutError:
-                # Start increasing timeout if already tried twice..
-                if attempt > 1:
-                    timeout = timeout * 2
-                _LOGGER.debug('%s Timeout requesting from %s',
-                              start_request_time, endpoint)
+                resp.raise_for_status()
+                return data
             except ClientError as err:
-                if attempt == DEFAULT_REQUEST_RETRIES - 1:
-                    raise RequestError('{} Client Error while requesting '
-                                       'data from {}: {}'.format(
-                                           start_request_time, endpoint,
-                                           err))
+                if "401" in str(err):
+                    if self._retry_security_token:
+                        raise SecurityTokenError(
+                            "Couldn't retrieve valid security token after several tries"
+                        )
 
-                _LOGGER.warning('%s Error requesting from %s; retrying: '
-                                '%s', start_request_time, endpoint, err)
-                await asyncio.sleep(5)
+                    _LOGGER.info("401 detected; attempting to get a new security token")
+                    self._retry_security_token = True
+                    await self.authenticate(self._username, self._password)
+                    return await self.request(
+                        method,
+                        full_url=url,
+                        headers=headers,
+                        params=params,
+                        json=json,
+                        **kwargs
+                    )
 
-        raise RequestError('{} Constant timeouts while requesting data '
-                           'from {}'.format(start_request_time, endpoint))
-
-    async def _update_device_state(self) -> None:
-        async with self._update_lock:
-            if datetime.utcnow() - self._last_update >\
-                    MIN_TIME_BETWEEN_UPDATES:
-                self.online = await self._get_device_states()
-
-    async def _get_device_states(self) -> bool:
-        _LOGGER.debug('Retrieving new device states')
-        try:
-            devices_resp = await self._request('get', DEVICE_LIST_ENDPOINT)
-        except RequestError as err:
-            _LOGGER.error('Getting device states failed: %s', err)
-            return False
-
-        if devices_resp is None:
-            return False
-
-        return_code = int(devices_resp.get('ReturnCode', 1))
-
-        if return_code != 0:
-            if return_code == -3333:
-                # Login error, need to retrieve a new token next time.
-                self._security_token = None
-                _LOGGER.debug('Security token expired')
-            else:
-                _LOGGER.error(
-                    'Error %s while retrieving states: %s',
-                    devices_resp.get('ReturnCode'),
-                    devices_resp.get('ErrorMessage', 'Unknown Error'))
-            return False
-
-        self._store_device_states(devices_resp.get('Devices', []))
-        _LOGGER.debug('New device states retrieved')
-        return True
-
-    def _store_device_states(self, devices: dict) -> None:
-        for device in self._devices:
-            myq_device = next(
-                (element for element in devices
-                 if element.get('MyQDeviceId') == device['device_id']), None)
-
-            if myq_device is not None:
-                device['device_info'] = myq_device
-                continue
-
-        self._last_update = datetime.utcnow()
-
-    async def authenticate(self, username: str, password: str) -> None:
-        """Authenticate against the API."""
-        self._credentials = {
-            'username': username,
-            'password': password,
-        }
-
-        await self._get_security_token()
-
-    async def _get_security_token(self) -> None:
-        """Request a security token."""
-        _LOGGER.debug('Requesting security token.')
-        if self._credentials is None:
-            return
-
-        # Make sure only 1 request can be sent at a time.
-        async with self._security_token_lock:
-            # Confirm there is still no security token.
-            if self._security_token is None:
-                login_resp = await self._request(
-                    'post',
-                    LOGIN_ENDPOINT,
-                    json=self._credentials,
-                    login_request=True,
+                raise RequestError(
+                    "Error requesting data from {0}: {1}".format(
+                        url, data["description"]
+                    )
                 )
 
-                return_code = int(login_resp.get('ReturnCode', 1))
-                if return_code != 0:
-                    if return_code == 203:
-                        # Invalid username or password.
-                        _LOGGER.debug('Invalid username or password')
-                        self._credentials = None
-                    raise MyQError(login_resp['ErrorMessage'])
+    async def authenticate(self, username: str, password: str) -> None:
+        """Authenticate and get a security token."""
+        self._username = username
+        self._password = password
 
-                self._security_token = login_resp['SecurityToken']
+        # Retrieve and store the initial security token:
+        auth_resp = await self.request(
+            "post", endpoint="Login", json={"Username": username, "Password": password}
+        )
+        self._security_token = auth_resp["SecurityToken"]
+        self._retry_security_token = False
 
-    async def get_devices(self, covers_only: bool = True) -> list:
-        """Get a list of all devices associated with the account."""
-        from .device import MyQDevice
+        # Retrieve and store account info:
+        self._account_info = await self.request(
+            "get", endpoint="My", params={"expand": "account"}
+        )
 
-        _LOGGER.debug('Retrieving list of devices')
-        devices_resp = await self._request('get', DEVICE_LIST_ENDPOINT)
-        # print(json.dumps(devices_resp, indent=4))
+        # Retrieve and store initial set of devices:
+        await self.update_device_info()
 
-        device_list = []
-        if devices_resp is None:
-            return device_list
+    async def update_device_info(self) -> dict:
+        """Get up-to-date device info."""
+        devices_resp = await self.request(
+            "get", endpoint="Accounts/{0}/Devices".format(self.account_id)
+        )
 
-        for device in devices_resp['Devices']:
-            if not covers_only or \
-               device['MyQDeviceTypeName'] in SUPPORTED_DEVICE_TYPE_NAMES:
-
-                self._devices.append({
-                    'device_id': device['MyQDeviceId'],
-                    'device_info': device
-                })
-                myq_device = MyQDevice(
-                    self._devices[-1], self._brand, self)
-                device_list.append(myq_device)
-
-        # Store current device states.
-        self._store_device_states(devices_resp.get('Devices', []))
-
-        _LOGGER.debug('List of devices retrieved')
-        return device_list
+        for device_json in devices_resp["items"]:
+            serial_number = device_json["serial_number"]
+            if serial_number in self.devices:
+                device = self.devices[serial_number]
+                device.device_json = device_json
+            else:
+                self.devices[device_json["serial_number"]] = Device(self, device_json)
 
 
 async def login(
-        username: str, password: str, brand: str,
-        websession: ClientSession = None) -> API:
+    username: str, password: str, brand: str, websession: ClientSession = None
+) -> API:
     """Log in to the API."""
     api = API(brand, websession)
     await api.authenticate(username, password)

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -1,6 +1,6 @@
 """Define MyQ devices."""
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from .errors import RequestError
 
@@ -32,7 +32,7 @@ class MyQDevice:
     @property
     def close_allowed(self) -> bool:
         """Return whether the device can be closed unattended."""
-        return self.device_json["state"].get("is_unattended_close_allowed")
+        return self.device_json["state"].get("is_unattended_close_allowed") is True
 
     @property
     def device_family(self) -> str:
@@ -55,7 +55,7 @@ class MyQDevice:
         return self.device_json["device_type"]
 
     @property
-    def firmware_version(self) -> str:
+    def firmware_version(self) -> Optional[str]:
         """Return the family in which this device lives."""
         return self.device_json["state"].get("firmware_version")
 
@@ -67,20 +67,20 @@ class MyQDevice:
     @property
     def online(self) -> bool:
         """Return whether the device is online."""
-        return self.device_json.get("online")
+        return self.device_json.get("online") is True
 
     @property
     def open_allowed(self) -> bool:
         """Return whether the device can be opened unattended."""
-        return self.device_json["state"].get("is_unattended_open_allowed")
+        return self.device_json["state"].get("is_unattended_open_allowed") is True
 
     @property
-    def parent_device_id(self) -> str:
+    def parent_device_id(self) -> Optional[str]:
         """Return the device ID (serial number) of this device's parent."""
         return self.device_json.get("parent_device_id")
 
     @property
-    def state(self) -> str:
+    def state(self) -> Optional[str]:
         """Return the current state of the device."""
         return self.device_json["state"].get("door_state")
 

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -87,21 +87,21 @@ class Device:
     @state.setter
     def state(self, value: str) -> None:
         """Set the current state of the device."""
-        if not self.state:
+        if not self.device_json["state"].get("door_state"):
             return
-
-        self.state = value
+        self.device_json["state"]["door_state"] = value
 
     async def _send_state_command(self, state_command: str) -> None:
         """Instruct the API to change the state of the device."""
-        if self.state is None:
+        # If the user tries to open or close, say, a gateway, throw an exception:
+        if not self.state:
             raise RequestError(
                 "Cannot change state of device type: {0}".format(self.device_type)
             )
 
         await self._api.request(
             "put",
-            endpoint="Accounts/{0}/Devices/{1}/actions".format(
+            "Accounts/{0}/Devices/{1}/actions".format(
                 self._api.account_id, self.device_id
             ),
             json={"action_type": state_command},

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -21,7 +21,7 @@ STATE_TRANSITION = "transition"
 STATE_UNKNOWN = "unknown"
 
 
-class Device:
+class MyQDevice:
     """Define a generic device."""
 
     def __init__(self, api: "API", device_json: dict):

--- a/pymyq/errors.py
+++ b/pymyq/errors.py
@@ -17,9 +17,3 @@ class RequestError(MyQError):
     """Define an exception related to bad HTTP requests."""
 
     pass
-
-
-class UnsupportedBrandError(MyQError):
-    """Define an exception related to unsupported brands."""
-
-    pass

--- a/pymyq/errors.py
+++ b/pymyq/errors.py
@@ -7,6 +7,12 @@ class MyQError(Exception):
     pass
 
 
+class InvalidCredentialsError(MyQError):
+    """Define an exception related to invalid credentials."""
+
+    pass
+
+
 class RequestError(MyQError):
     """Define an exception related to bad HTTP requests."""
 

--- a/pymyq/errors.py
+++ b/pymyq/errors.py
@@ -19,12 +19,6 @@ class RequestError(MyQError):
     pass
 
 
-class SecurityTokenError(MyQError):
-    """Define an exception related issues with the security token."""
-
-    pass
-
-
 class UnsupportedBrandError(MyQError):
     """Define an exception related to unsupported brands."""
 

--- a/pymyq/errors.py
+++ b/pymyq/errors.py
@@ -13,6 +13,12 @@ class RequestError(MyQError):
     pass
 
 
+class SecurityTokenError(MyQError):
+    """Define an exception related issues with the security token."""
+
+    pass
+
+
 class UnsupportedBrandError(MyQError):
     """Define an exception related to unsupported brands."""
 


### PR DESCRIPTION
This PR reworks the library to be compatible with MyQ API version 5. It fixes https://github.com/arraylabs/pymyq/issues/22 and fixes https://github.com/arraylabs/pymyq/issues/25. Because it is a huge rewrite (representing a completely new API), this should bump the version to 2.0.0 IMO.

In addition to this rework, this PR performs some cleanup of the library:

* Removes unnecessary `asyncio` locks
* Removes unnecessary endpoint constants
* Removes unnecessary methods to open and close a websession
* Removes unnecessary `login_request` parameter to the `_request` method
* Simplifies retry logic
* Adds `black` for nicer formatting consistent with Home Assistant (formatting, `pylintrc`, and `.flake8`)

Lastly, this PR removes a lot of the retry/rate limiting/etc. logic that was present, as that should really be the responsibility of the implementing party (Home Assistant, etc.).