### PR TITLE
Format device properties for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,17 @@ asyncio.get_event_loop().run_until_complete(main())
 
 ## Device Properties
 
-`close_allowed`: Return whether the device can be closed unattended.
-`device_family`: Return the family in which this device lives.
-`device_id`: Return the device ID (serial number).
-`device_platform`: Return the device platform.
-`device_type`: Return the device type.
-`firmware_version`: Return the family in which this device lives.
-`name`: Return the device name.
-`online`: Return whether the device is online.
-`open_allowed`: Return whether the device can be opened unattended.
-`parent_device_id`: Return the device ID (serial number) of this device's parent.
-`state`: Return the current state of the device.
+* `close_allowed`: Return whether the device can be closed unattended.
+* `device_family`: Return the family in which this device lives.
+* `device_id`: Return the device ID (serial number).
+* `device_platform`: Return the device platform.
+* `device_type`: Return the device type.
+* `firmware_version`: Return the family in which this device lives.
+* `name`: Return the device name.
+* `online`: Return whether the device is online.
+* `open_allowed`: Return whether the device can be opened unattended.
+* `parent_device_id`: Return the device ID (serial number) of this device's parent.
+* `state`: Return the current state of the device.
 
 ## Methods
 


### PR DESCRIPTION
Using bullets to force line breaks, just like the Methods section below.

Here's github's visual diff of the changes:

<img width="1178" alt="Screen Shot 2019-12-27 at 12 25 04 PM" src="https://user-images.githubusercontent.com/483223/71531547-044b1b00-28a4-11ea-99a4-c862524e6598.png">
