### PR TITLE
Remove multidict from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ async_timeout>=3.0.1
 attrs==18.2.0
 chardet==3.0.4
 idna==2.7
-multidict==4.4.2
 pycares==2.3.0
 yarl==1.2.6


### PR DESCRIPTION
Resolves #69. Based on @dseven's [suggestion](https://github.com/arraylabs/pymyq/issues/69#issuecomment-761600599), `multidict` was removed as a package from `requirements.txt`.

### Testing
1. In the project directory, run `python3 -m pip install -r requirements.txt`
2. Ensure there are no warnings or errors with the install process like below:
![image](https://user-images.githubusercontent.com/36345325/104835312-967ce300-585a-11eb-8667-d5089e2616e0.png)
