### PR TITLE
v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This is a Python 3.5+ module aiming to interact with the Chamberlain MyQ API.
+This is a Python 3.8+ module aiming to interact with the Chamberlain MyQ API.
 
 Code is licensed under the MIT license.
 
@@ -51,6 +51,14 @@ async def main() -> None:
       devices = myq.covers
       # >>> {"serial_number123": <Device>}
 
+      # Return only lamps devices:
+      devices = myq.lamps
+      # >>> {"serial_number123": <Device>}
+
+      # Return only gateway devices:
+      devices = myq.gateways
+      # >>> {"serial_number123": <Device>}
+      
       # Return *all* devices:
       devices = myq.devices
       # >>> {"serial_number123": <Device>, "serial_number456": <Device>}
@@ -58,29 +66,74 @@ async def main() -> None:
 
 asyncio.get_event_loop().run_until_complete(main())
 ```
+## API Properties
+
+* `accounts`: dictionary with all accounts
+* `covers`: dictionary with all covers
+* `devices`: dictionary with all devices  
+* `gateways`: dictionary with all gateways
+* `lamps`: dictionary with all lamps
+* `last_state_update`: datetime (in UTC) last state update was retrieved
+* `password`: password used for authentication. Can only be set, not retrieved
+* `username`: username for authentication.
+
+## Account Properties
+
+* `id`: ID for the account
+* `name`: Name of the account
 
 ## Device Properties
 
+* `account`: Return account associated with device
 * `close_allowed`: Return whether the device can be closed unattended.
 * `device_family`: Return the family in which this device lives.
 * `device_id`: Return the device ID (serial number).
 * `device_platform`: Return the device platform.
 * `device_type`: Return the device type.
 * `firmware_version`: Return the family in which this device lives.
+* `href`: URI for device  
 * `name`: Return the device name.
 * `online`: Return whether the device is online.
 * `open_allowed`: Return whether the device can be opened unattended.
 * `parent_device_id`: Return the device ID (serial number) of this device's parent.
 * `state`: Return the current state of the device.
+* `state_update`: Returns datetime when device was last updated
 
-## Methods
+## API Methods
+
+These are coroutines and need to be `await`ed – see `example.py` for examples.
+
+* `authenticate`: Authenticate (or re-authenticate) to MyQ. Call this to
+  re-authenticate immediately after changing username and/or password otherwise
+  new username/password will only be used when token has to be refreshed.
+* `update_device_info`: Retrieve info and status for accounts and devices
+
+
+## Device Methods
 
 All of the routines on the `MyQDevice` class are coroutines and need to be
 `await`ed – see `example.py` for examples.
 
-* `close`: close the device
-* `open`: open the device
-* `update`: get the latest device info (state, etc.)
+* `update`: get the latest device info (state, etc.). Note that 
+  this runs api.update_device_info and thus all accounts/devices will be updated
+
+## Cover Methods
+
+All Device methods in addition to:
+* `close`: close the cover
+* `open`: open the cover
+
+## Lamp Methods
+
+All Device methods in addition to:
+* `turnon`: turn lamp on
+* `turnoff`: turn lamp off
+
+
+# Acknowledgement
+
+Huge thank you to [hjdhjd](https://github.com/hjdhjd) for figuring out the updated V6 API and 
+sharing his work with us. 
 
 # Disclaimer
 

--- a/example.py
+++ b/example.py
@@ -14,7 +14,6 @@ EMAIL = "<EMAIL>"
 PASSWORD = "<PASSWORD>"
 OPEN_CLOSE = True
 
-
 def print_info(number: int, device):
     print(f"      Device {number + 1}: {device.name}")
     print(f"      Device Online: {device.online}")

--- a/example.py
+++ b/example.py
@@ -12,8 +12,7 @@ _LOGGER = logging.getLogger()
 
 EMAIL = "<EMAIL>"
 PASSWORD = "<PASSWORD>"
-ISSUE_COMMANDS = False
-
+ISSUE_COMMANDS = True
 
 def print_info(number: int, device):
     print(f"      Device {number + 1}: {device.name}")
@@ -76,9 +75,6 @@ async def main() -> None:
                                             _LOGGER.error(f"Error when trying to open {device.name}: {str(err)}")
                                 else:
                                     print(f"Opening of garage door {device.name} is not allowed.")
-
-                                if device.open_allowed and device.close_allowed:
-                                    await asyncio.sleep(5)
 
                                 if device.close_allowed:
                                     if device.state == STATE_CLOSED:

--- a/example.py
+++ b/example.py
@@ -13,6 +13,26 @@ EMAIL = "<EMAIL>"
 PASSWORD = "<PASSWORD>"
 OPEN_CLOSE = False
 
+
+def print_info(number: int, device):
+    print(f"      Device {number + 1}: {device.name}")
+    print(f"      Device Online: {device.online}")
+    print(f"      Device ID: {device.device_id}")
+    print(
+        f"      Parent Device ID: {device.parent_device_id}",
+    )
+    print(f"      Device Family: {device.device_family}")
+    print(
+        f"      Device Platform: {device.device_platform}",
+    )
+    print(f"      Device Type: {device.device_type}")
+    print(f"      Firmware Version: {device.firmware_version}")
+    print(f"      Open Allowed: {device.open_allowed}")
+    print(f"      Close Allowed: {device.close_allowed}")
+    print(f"      Current State: {device.state}")
+    print("      ---------")
+
+
 async def main() -> None:
     """Create the aiohttp session and run the example."""
     logging.basicConfig(level=logging.DEBUG)
@@ -22,33 +42,70 @@ async def main() -> None:
             print(f"{EMAIL} {PASSWORD}")
             api = await login(EMAIL, PASSWORD, websession)
 
-            # Get the account ID:
-            _LOGGER.info("Account ID: %s", api.account_id)
+            for account in api.accounts:
+                print(f"Account ID: {account}")
+                print(f"Account Name: {api.accounts[account]}")
 
-            # Get all devices listed with this account – note that you can use
-            # api.covers to only examine covers:
-            for idx, device_id in enumerate(api.devices):
-                device = api.devices[device_id]
-                _LOGGER.info("---------")
-                _LOGGER.info("Device %s: %s", idx + 1, device.name)
-                _LOGGER.info("Device Online: %s", device.online)
-                _LOGGER.info("Device ID: %s", device.device_id)
-                _LOGGER.info("Parent Device ID: %s", device.parent_device_id)
-                _LOGGER.info("Device Family: %s", device.device_family)
-                _LOGGER.info("Device Platform: %s", device.device_platform)
-                _LOGGER.info("Device Type: %s", device.device_type)
-                _LOGGER.info("Firmware Version: %s", device.firmware_version)
-                _LOGGER.info("Open Allowed: %s", device.open_allowed)
-                _LOGGER.info("Close Allowed: %s", device.close_allowed)
-                _LOGGER.info("Current State: %s", device.state)
+                # Get all devices listed with this account – note that you can use
+                # api.covers to only examine covers or api.lamps for only lamps.
+                print(f"  GarageDoors: {len(api.covers)}")
+                print("  ---------------")
+                if len(api.covers) != 0:
+                    for idx, device_id in enumerate(
+                        device_id
+                        for device_id in api.covers
+                        if api.devices[device_id].account == account
+                    ):
+                        device = api.devices[device_id]
+                        print_info(number=idx, device=device)
 
-                if OPEN_CLOSE:
-                    try:
-                        await device.open()
-                        await asyncio.sleep(15)
-                        await device.close()
-                    except RequestError as err:
-                        _LOGGER.error(err)
+                        if OPEN_CLOSE:
+                            try:
+                                if device.open_allowed:
+                                    print(f"Opening garage door {device.name}")
+                                    await device.open()
+                                if device.open_allowed and device.close_allowed:
+                                    await asyncio.sleep(15)
+                                if device.close_allowed:
+                                    print(f"Closing garage door {device.name}")
+                                    await device.close()
+                            except RequestError as err:
+                                _LOGGER.error(err)
+                    print("  ------------------------------")
+                print(f"  Lamps: {len(api.lamps)}")
+                print("  ---------")
+                if len(api.lamps) != 0:
+                    for idx, device_id in enumerate(
+                        device_id
+                        for device_id in api.lamps
+                        if api.devices[device_id].account == account
+                    ):
+                        device = api.devices[device_id]
+                        print_info(number=idx, device=device)
+
+                        if OPEN_CLOSE:
+                            try:
+                                print(f"Turning lamp {device.name} on")
+                                await device.turnon()
+                                await asyncio.sleep(15)
+                                print(f"Turning lamp {device.name} off")
+                                await device.turnoff()
+                            except RequestError as err:
+                                _LOGGER.error(err)
+                    print("  ------------------------------")
+
+                print(f"  Gateways: {len(api.gateways)}")
+                print("  ------------")
+                if len(api.gateways) != 0:
+                    for idx, device_id in enumerate(
+                        device_id
+                        for device_id in api.gateways
+                        if api.devices[device_id].account == account
+                    ):
+                        device = api.devices[device_id]
+                        print_info(number=idx, device=device)
+
+                print("------------------------------")
 
         except MyQError as err:
             _LOGGER.error("There was an error: %s", err)

--- a/pymyq/__version__.py
+++ b/pymyq/__version__.py
@@ -1,2 +1,2 @@
 """Define a version constant."""
-__version__ = '2.0.15'
+__version__ = '3.0.0'

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -277,7 +277,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                 message = (
                     f"Error requesting data from {url}: {err.status} - {err.message}"
                 )
-                _LOGGER.error(message)
+                _LOGGER.debug(message)
                 if getattr(err, 'status') and err.status == 401:
                     # Received unauthorized, reset token and start task to get a new one.
                     self._security_token = (None, None, self._security_token[2])
@@ -290,7 +290,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                 message = (
                     f"Error requesting data from {url}: {str(err)}"
                 )
-                _LOGGER.error(message)
+                _LOGGER.debug(message)
                 raise RequestError(message)
 
     async def _oauth_authenticate(self) -> (str, int):
@@ -572,7 +572,11 @@ async def login(username: str, password: str, websession: ClientSession = None) 
     # Set the user agent in the headers.
     api = API(username=username, password=password, websession=websession)
     _LOGGER.debug("Performing initial authentication into MyQ")
-    await api.authenticate(wait=True)
+    try:
+        await api.authenticate(wait=True)
+    except AuthenticationError as err:
+        _LOGGER.error(f"Authentication failed: {str(err)}")
+        raise err
 
     # Retrieve and store initial set of devices:
     _LOGGER.debug("Retrieving MyQ information")

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -173,12 +173,12 @@ class API:  # pylint: disable=too-many-instance-attributes
                 message = (
                     f"Error requesting data from {url}: {err.status} - {err.message}"
                 )
-                _LOGGER.error(message)
+                _LOGGER.debug(message)
                 raise RequestError(message)
 
             except ClientError as err:
                 message = f"Error requesting data from {url}: {str(err)}"
-                _LOGGER.error(message)
+                _LOGGER.debug(message)
                 raise RequestError(message)
 
         # The MyQ API can time out if multiple concurrent requests are made, so
@@ -219,7 +219,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                         await self.authenticate(wait=True)
                     except AuthenticationError as auth_err:
                         message = f"Error trying to re-authenticate to myQ service: {str(auth_err)}"
-                        _LOGGER.error(message)
+                        _LOGGER.debug(message)
                         raise AuthenticationError(message)
                 else:
                     # We still have a token, we can continue this request with that token and schedule
@@ -256,7 +256,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                             # Raise authentication error, we need a new token to continue and not getting it right
                             # now.
                             message = f"Error trying to re-authenticate to myQ service: {str(auth_err)}"
-                            _LOGGER.error(message)
+                            _LOGGER.debug(message)
                             raise AuthenticationError(message)
                     else:
                         # Some other error, re-raise.
@@ -351,7 +351,7 @@ class API:  # pylint: disable=too-many-instance-attributes
             message = (
                 "Invalid MyQ credentials provided. Please recheck login and password."
             )
-            _LOGGER.error(message)
+            _LOGGER.debug(message)
             raise InvalidCredentialsError(message)
 
         # Intercept redirect back to MyQ iOS app

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -197,9 +197,10 @@ class API:  # pylint: disable=too-many-instance-attributes
                 authentication_task = await self.authenticate(wait=False)
                 if authentication_task.done():
                     _LOGGER.debug("Scheduled token refresh completed, ensuring no exception.")
+                    self._authentication_task = None
                     try:
                         # Get the result so any exception is raised.
-                        self._authentication_task.result()
+                        authentication_task.result()
                     except asyncio.CancelledError:
                         pass
                     except (RequestError, AuthenticationError) as auth_err:

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -171,6 +171,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                     data=data,
                     json=json,
                     allow_redirects=allow_redirects,
+                    use_websession=True,
                 )
             except ClientResponseError as err:
                 message = (

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -31,7 +31,7 @@ from .request import MyQRequest, REQUEST_METHODS
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_STATE_UPDATE_INTERVAL = timedelta(seconds=20)
+DEFAULT_STATE_UPDATE_INTERVAL = timedelta(seconds=10)
 DEFAULT_TOKEN_REFRESH = 10 * 60  # 10 minutes
 
 

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -597,7 +597,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                 # Request is for specific account, thus restrict retrieval to the 1 account.
                 if self.accounts.get(for_account) is None:
                     # Checking to ensure we know the account, but this should never happen.
-                    _LOGGER.debug(f"Unable to perform update request for account {account} as it is not known.")
+                    _LOGGER.debug(f"Unable to perform update request for account {for_account} as it is not known.")
                     accounts = {}
                 else:
                     accounts = ({for_account: self.accounts.get(for_account)})

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -359,7 +359,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                 )
 
             _LOGGER.debug(f"Received token that will expire in {expires} seconds")
-            self._security_token = (self._security_token[0], datetime.utcnow()+timedelta(seconds=int(expires/2)))
+            self._security_token = (token, datetime.utcnow()+timedelta(seconds=int(expires/2)))
 
     async def update_device_info(self) -> Optional[dict]:
         """Get up-to-date device info."""

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -540,10 +540,11 @@ class API:  # pylint: disable=too-many-instance-attributes
                             # When performing commands we might update the state temporary, need to ensure
                             # that the state is not set back to something else if MyQ does not yet have updated
                             # state
-                            last_update = myqdevice.device_json["state"].get("last_update", "N/A")
+                            last_update = myqdevice.device_json["state"].get("last_update")
                             myqdevice.device_json = device
 
-                            if myqdevice.device_json["state"].get("last_update") != last_update:
+                            if myqdevice.device_json["state"].get("last_update") is None or \
+                                    myqdevice.device_json["state"].get("last_update") != last_update:
                                 # MyQ has updated device state, reset ours ensuring we have the one from MyQ.
                                 _LOGGER.debug(f"State for device {myqdevice.name} was updated")
                                 myqdevice.state = None

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -115,7 +115,7 @@ class API:  # pylint: disable=too-many-instance-attributes
     @property
     def _code_verifier(self) -> str:
         if self._codeverifier is None:
-            self._codeverifier = generate_code_verifier(length=128)
+            self._codeverifier = generate_code_verifier(length=43)
         return self._codeverifier
 
     @property
@@ -243,7 +243,10 @@ class API:  # pylint: disable=too-many-instance-attributes
             method="get",
             returns="text",
             url=OAUTH_AUTHORIZE_URI,
-            headers={"redirect": "follow"},
+            headers={
+                "redirect": "follow",
+                "User-Agent": "null",
+            },
             params={
                 "client_id": OAUTH_CLIENT_ID,
                 "code_challenge": get_code_challenge(self._code_verifier),
@@ -360,7 +363,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                 )
 
             _LOGGER.debug(f"Received token that will expire in {expires} seconds")
-            self._security_token = (token, datetime.utcnow()+timedelta(seconds=int(expires/2)), datetime.utcnow())
+            self._security_token = (token, datetime.utcnow()+timedelta(seconds=int(expires/2)), datetime.now())
 
     async def update_device_info(self) -> Optional[dict]:
         """Get up-to-date device info."""

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -545,6 +545,7 @@ class API:  # pylint: disable=too-many-instance-attributes
 
                             if myqdevice.device_json["state"].get("last_update") != last_update:
                                 # MyQ has updated device state, reset ours ensuring we have the one from MyQ.
+                                _LOGGER.debug(f"State for device {myqdevice.name} was updated")
                                 myqdevice.state = None
 
                             myqdevice.state_update = state_update_timestmp

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -540,7 +540,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                             # When performing commands we might update the state temporary, need to ensure
                             # that the state is not set back to something else if MyQ does not yet have updated
                             # state
-                            last_update = myqdevice.device_json["state"]["last_update"]
+                            last_update = myqdevice.device_json["state"].get("last_update")
                             myqdevice.device_json = device
 
                             if myqdevice.device_json["state"]["last_update"] != last_update:

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -79,7 +79,8 @@ class API:  # pylint: disable=too-many-instance-attributes
         self._security_token = (
             None,
             None,
-        )  # type: Tuple[Optional[str], Optional[datetime]]
+            None,
+        )  # type: Tuple[Optional[str], Optional[datetime], Optional[datetime]]
         self._myqrequests = MyQRequest(websession or ClientSession())
         self.accounts = {}
         self.devices = {}  # type: Dict[str, MyQDevice]
@@ -190,7 +191,7 @@ class API:  # pylint: disable=too-many-instance-attributes
             or self._security_token[1] <= datetime.utcnow()
         ):
             _LOGGER.debug(
-                f"Refreshing token, last refresh was {self._security_token[1]}"
+                f"Refreshing token, last refresh was {self._security_token[2]}"
             )
             try:
                 await self.authenticate()
@@ -353,13 +354,13 @@ class API:  # pylint: disable=too-many-instance-attributes
             token, expires = await self._oauth_authenticate()
             if token is None:
                 _LOGGER.debug("No security token received.")
-                self._security_token = (None, None)
+                self._security_token = (None, None, self._security_token[2])
                 raise RequestError(
                     "Authentication response did not contain a security token yet one is expected."
                 )
 
             _LOGGER.debug(f"Received token that will expire in {expires} seconds")
-            self._security_token = (token, datetime.utcnow()+timedelta(seconds=int(expires/2)))
+            self._security_token = (token, datetime.utcnow()+timedelta(seconds=int(expires/2)), datetime.utcnow())
 
     async def update_device_info(self) -> Optional[dict]:
         """Get up-to-date device info."""

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -546,8 +546,9 @@ class API:  # pylint: disable=too-many-instance-attributes
                             if myqdevice.device_json["state"].get("last_update") is not None and \
                                     myqdevice.device_json["state"].get("last_update") != last_update:
                                 # MyQ has updated device state, reset ours ensuring we have the one from MyQ.
-                                _LOGGER.debug(f"State for device {myqdevice.name} was updated")
                                 myqdevice.state = None
+                                _LOGGER.debug(f"State for device {myqdevice.name} was updated to {myqdevice.state}")
+
 
                             myqdevice.state_update = state_update_timestmp
                         else:

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -171,7 +171,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                     data=data,
                     json=json,
                     allow_redirects=allow_redirects,
-                    use_websession=True,
+                    use_websession=False,
                 )
             except ClientResponseError as err:
                 message = (

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -450,7 +450,7 @@ class API:  # pylint: disable=too-many-instance-attributes
 
     async def _authenticate(self) -> None:
         # Retrieve and store the initial security token:
-        _LOGGER.debug(f"{self.__name__} Initiating OAuth authentication")
+        _LOGGER.debug("Initiating OAuth authentication")
         token, expires = await self._oauth_authenticate()
 
         if token is None:

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -234,7 +234,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                 _LOGGER.error(message)
                 raise RequestError(message)
 
-    async def _oauth_authenticate(self) -> str:
+    async def _oauth_authenticate(self) -> (str, int):
 
         # retrieve authentication page
         _LOGGER.debug("Retrieving authentication page")
@@ -335,7 +335,7 @@ class API:  # pylint: disable=too-many-instance-attributes
             expires = int(data.get('expires_in', DEFAULT_TOKEN_REFRESH))
         except ValueError:
             _LOGGER.debug(f"Expires {data.get('expires_in')} received is not an integer, using default.")
-            expires=DEFAULT_TOKEN_REFRESH
+            expires = DEFAULT_TOKEN_REFRESH
 
         return token, expires
 

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -543,7 +543,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                             last_update = myqdevice.device_json["state"].get("last_update")
                             myqdevice.device_json = device
 
-                            if myqdevice.device_json["state"].get("last_update") is None or \
+                            if myqdevice.device_json["state"].get("last_update") is not None and \
                                     myqdevice.device_json["state"].get("last_update") != last_update:
                                 # MyQ has updated device state, reset ours ensuring we have the one from MyQ.
                                 _LOGGER.debug(f"State for device {myqdevice.name} was updated")

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -31,7 +31,7 @@ from .request import MyQRequest, REQUEST_METHODS
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_STATE_UPDATE_INTERVAL = timedelta(seconds=5)
+DEFAULT_STATE_UPDATE_INTERVAL = timedelta(seconds=20)
 DEFAULT_TOKEN_REFRESH = timedelta(minutes=2)
 
 
@@ -367,10 +367,10 @@ class API:  # pylint: disable=too-many-instance-attributes
         next_available_call_dt = self._last_state_update + DEFAULT_STATE_UPDATE_INTERVAL
 
         if call_dt < next_available_call_dt:
-            _LOGGER.debug("Ignoring subsequent request within throttle window")
+            _LOGGER.debug("Ignoring device update request as it is within throttle window")
             return
 
-        _LOGGER.debug("Retrieving accounts")
+        _LOGGER.debug("Updating device information, starting with retrieving accounts")
         _, accounts_resp = await self.request(
             method="get", returns="json", url=ACCOUNTS_ENDPOINT
         )
@@ -448,7 +448,7 @@ async def login(username: str, password: str, websession: ClientSession = None) 
 
     # Set the user agent in the headers.
     api = API(username, password, websession)
-    _LOGGER.debug("Performing initial authentication inyo MyQ")
+    _LOGGER.debug("Performing initial authentication into MyQ")
     await api.authenticate()
 
     # Retrieve and store initial set of devices:

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -540,10 +540,10 @@ class API:  # pylint: disable=too-many-instance-attributes
                             # When performing commands we might update the state temporary, need to ensure
                             # that the state is not set back to something else if MyQ does not yet have updated
                             # state
-                            last_update = myqdevice.device_json["state"].get("last_update")
+                            last_update = myqdevice.device_json["state"].get("last_update", "N/A")
                             myqdevice.device_json = device
 
-                            if myqdevice.device_json["state"]["last_update"] != last_update:
+                            if myqdevice.device_json["state"].get("last_update") != last_update:
                                 # MyQ has updated device state, reset ours ensuring we have the one from MyQ.
                                 myqdevice.state = None
 

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -213,9 +213,6 @@ class API:  # pylint: disable=too-many-instance-attributes
                 or self._security_token[1] <= datetime.utcnow()
             ):
                 # Token has to be refreshed, get authentication task if running otherwise start a new one.
-                _LOGGER.debug(
-                    f"Refreshing token, last refresh was {self._security_token[2]}"
-                )
                 if self._security_token[0] is None:
                     # Wait for authentication task to be completed.
                     _LOGGER.debug(

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -32,7 +32,7 @@ from .request import MyQRequest, REQUEST_METHODS
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_STATE_UPDATE_INTERVAL = timedelta(seconds=20)
-DEFAULT_TOKEN_REFRESH = timedelta(minutes=30)
+DEFAULT_TOKEN_REFRESH = 10*60  # 10 minutes
 
 
 class HTMLElementFinder(HTMLParser):

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -603,7 +603,6 @@ class API:  # pylint: disable=too-many-instance-attributes
                     accounts = ({for_account: self.accounts.get(for_account)})
 
             for account in accounts:
-                _LOGGER.debug(f"Retrieving devices for account {self.accounts[account]}")
                 await self._get_devices_for_account(account=account)
 
             # Update our last update timestamp UNLESS this is for a specific account

--- a/pymyq/const.py
+++ b/pymyq/const.py
@@ -1,19 +1,22 @@
 """The myq constants."""
 
-API_BASE = "https://api.myqdevice.com/api/v{0}"
-BASE_API_VERSION = 5
-DEVICES_API_VERSION = 5.1
+OAUTH_CLIENT_ID = "IOS_CGI_MYQ"
+OAUTH_CLIENT_SECRET = "VUQ0RFhuS3lQV3EyNUJTdw=="
+OAUTH_BASE_URI = "https://partner-identity.myq-cloud.com"
+OAUTH_AUTHORIZE_URI = f"{OAUTH_BASE_URI}/connect/authorize"
+OAUTH_REDIRECT_URI = "com.myqops://ios"
+OAUTH_TOKEN_URI = f"{OAUTH_BASE_URI}/connect/token"
 
-LOGIN_ENDPOINT = "Login"
-ACCOUNT_INFORMATION_ENDPOINT = "My"
-ACCOUNTS_ENDPOINT = "Accounts"
-DEVICES_ENDPOINT = f"{ACCOUNTS_ENDPOINT}/{{0}}/Devices"
-ACTION_ENDPOINT = f"{ACCOUNTS_ENDPOINT}/{{0}}/Devices/{{1}}/actions"
+ACCOUNTS_ENDPOINT = "https://accounts.myq-cloud.com/api/v6.0/accounts"
+DEVICES_ENDPOINT = "https://devices.myq-cloud.com/api/v5.2/Accounts/{account_id}/Devices"
+
 
 DEVICE_TYPE = "device_type"
 DEVICE_TYPE_GATE = "gate"
 DEVICE_FAMILY = "device_family"
 DEVICE_FAMILY_GATEWAY = "gateway"
+DEVICE_FAMILY_GARAGEDOOR = "garagedoor"
+DEVICE_FAMLY_LAMP = "lamp"
 DEVICE_STATE = "state"
 DEVICE_STATE_ONLINE = "online"
 

--- a/pymyq/const.py
+++ b/pymyq/const.py
@@ -10,6 +10,7 @@ OAUTH_TOKEN_URI = f"{OAUTH_BASE_URI}/connect/token"
 ACCOUNTS_ENDPOINT = "https://accounts.myq-cloud.com/api/v6.0/accounts"
 DEVICES_ENDPOINT = "https://devices.myq-cloud.com/api/v5.2/Accounts/{account_id}/Devices"
 
+WAIT_TIMEOUT = 60
 
 DEVICE_TYPE = "device_type"
 DEVICE_TYPE_GATE = "gate"

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -128,7 +128,7 @@ class MyQDevice:
             wait_timeout = wait_timeout - 5
             await asyncio.sleep(5)
             try:
-                await self.update()
+                await self._api.update_device_info(for_account=self.account)
             except MyQError:
                 # Ignoring
                 pass
@@ -140,7 +140,7 @@ class MyQDevice:
             wait_timeout = wait_timeout - 5
             await asyncio.sleep(5)
             try:
-                await self.update()
+                await self._api.update_device_info(for_account=self.account)
             except MyQError:
                 # Ignoring
                 pass

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -78,7 +78,7 @@ class MyQDevice:
 
     @property
     def state(self) -> Optional[str]:
-        return self._device_state if not None else self.device_state
+        return self._device_state or self.device_state
 
     @state.setter
     def state(self, value: str) -> None:

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -134,7 +134,7 @@ class MyQDevice:
                 pass
 
         # Wait until the state is to what we want it to be
-        _LOGGER.debug(f"Waiting until device state for {self.name} is {current_state}")
+        _LOGGER.debug(f"Waiting until device state for {self.name} is {new_state}")
         wait_timeout = WAIT_TIMEOUT
         while self.state in current_state and wait_timeout > 0:
             wait_timeout = wait_timeout - 5

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -14,13 +14,14 @@ _LOGGER = logging.getLogger(__name__)
 class MyQDevice:
     """Define a generic device."""
 
-    def __init__(self, api: "API", device_json: dict, account: str) -> None:
+    def __init__(self, api: "API", device_json: dict, account: str, state_update: datetime) -> None:
         """Initialize.
         :type account: str
         """
         self._api = api
         self._account = account
         self.device_json = device_json
+        self.state_update = state_update
 
     @property
     def account(self) -> str:

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -1,5 +1,6 @@
 """Define MyQ devices."""
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from .const import DEVICE_TYPE

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -122,7 +122,7 @@ class MyQDevice:
         # First wait until door state is actually updated.
         wait_timeout = WAIT_TIMEOUT
         while (
-            last_state_update == self.device_json["state"]["last_update"] and wait_timeout > 0
+            last_state_update == self.device_json["state"].get("last_update", datetime.utcnow()) and wait_timeout > 0
         ):
             wait_timeout = wait_timeout - 5
             await asyncio.sleep(5)

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple, List
 
 from .const import DEVICE_TYPE, WAIT_TIMEOUT
 from .errors import RequestError, MyQError
@@ -118,7 +118,7 @@ class MyQDevice:
         """Get the latest info for this device."""
         await self._api.update_device_info()
 
-    async def wait_for_state(self, current_state: Tuple, new_state: Tuple, last_state_update: datetime) -> bool:
+    async def wait_for_state(self, current_state: List, new_state: List, last_state_update: datetime) -> bool:
         # First wait until door state is actually updated.
         _LOGGER.debug(f"Waiting until device state has been updated for {self.name}")
         wait_timeout = WAIT_TIMEOUT

--- a/pymyq/device.py
+++ b/pymyq/device.py
@@ -120,6 +120,7 @@ class MyQDevice:
 
     async def wait_for_state(self, current_state: Tuple, new_state: Tuple, last_state_update: datetime) -> bool:
         # First wait until door state is actually updated.
+        _LOGGER.debug(f"Waiting until device state has been updated for {self.name}")
         wait_timeout = WAIT_TIMEOUT
         while (
             last_state_update == self.device_json["state"].get("last_update", datetime.utcnow()) and wait_timeout > 0
@@ -133,6 +134,7 @@ class MyQDevice:
                 pass
 
         # Wait until the state is to what we want it to be
+        _LOGGER.debug(f"Waiting until device state for {self.name} is {current_state}")
         wait_timeout = WAIT_TIMEOUT
         while self.state in current_state and wait_timeout > 0:
             wait_timeout = wait_timeout - 5

--- a/pymyq/errors.py
+++ b/pymyq/errors.py
@@ -13,6 +13,12 @@ class InvalidCredentialsError(MyQError):
     pass
 
 
+class AuthenticationError(MyQError):
+    """Define an exception related to invalid credentials."""
+
+    pass
+
+
 class RequestError(MyQError):
     """Define an exception related to bad HTTP requests."""
 

--- a/pymyq/garagedoor.py
+++ b/pymyq/garagedoor.py
@@ -81,7 +81,7 @@ class MyQGaragedoor(MyQDevice):
             current_state=tuple(STATE_OPENING),
             new_state=tuple(STATE_OPEN),
             last_state_update=self.device_json["state"].get("last_update"),
-        ), name="MyQ_Authenticate",
+        ), name="MyQ_WaitForClose",
         )
         if not wait_for_state:
             return wait_for_state_task
@@ -107,7 +107,7 @@ class MyQGaragedoor(MyQDevice):
             current_state=tuple(STATE_OPENING),
             new_state=tuple(STATE_OPEN),
             last_state_update=self.device_json["state"].get("last_update"),
-        ), name="MyQ_Authenticate",
+        ), name="MyQ_WaitForOpen",
         )
 
         if not wait_for_state:

--- a/pymyq/garagedoor.py
+++ b/pymyq/garagedoor.py
@@ -78,8 +78,8 @@ class MyQGaragedoor(MyQDevice):
             return True
 
         wait_for_state_task = asyncio.create_task(self.wait_for_state(
-            current_state=tuple(STATE_OPENING),
-            new_state=tuple(STATE_OPEN),
+            current_state=[STATE_OPENING],
+            new_state=[STATE_OPEN],
             last_state_update=self.device_json["state"].get("last_update"),
         ), name="MyQ_WaitForClose",
         )
@@ -104,8 +104,8 @@ class MyQGaragedoor(MyQDevice):
             self.state = STATE_OPENING
 
         wait_for_state_task = asyncio.create_task(self.wait_for_state(
-            current_state=tuple(STATE_OPENING),
-            new_state=tuple(STATE_OPEN),
+            current_state=[STATE_OPENING],
+            new_state=[STATE_OPEN],
             last_state_update=self.device_json["state"].get("last_update"),
         ), name="MyQ_WaitForOpen",
         )

--- a/pymyq/garagedoor.py
+++ b/pymyq/garagedoor.py
@@ -27,11 +27,11 @@ WAIT_TIMEOUT = 60
 class MyQGaragedoor(MyQDevice):
     """Define a generic device."""
 
-    def __init__(self, api: "API", device_json: dict, account: str) -> None:
+    def __init__(self, api: "API", device_json: dict, account: str, state_update: datetime) -> None:
         """Initialize.
         :type account: str
         """
-        super().__init__(api=api, account=account, device_json=device_json)
+        super().__init__(api=api, account=account, device_json=device_json, state_update=state_update)
 
     @property
     def close_allowed(self) -> bool:

--- a/pymyq/garagedoor.py
+++ b/pymyq/garagedoor.py
@@ -1,0 +1,92 @@
+"""Define MyQ devices."""
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from .device import MyQDevice
+
+if TYPE_CHECKING:
+    from .api import API
+
+_LOGGER = logging.getLogger(__name__)
+
+COMMAND_URI = \
+    "https://account-devices-gdo.myq-cloud.com/api/v5.2/Accounts/{account_id}/door_openers/{device_serial}/{command}"
+COMMAND_CLOSE = "close"
+COMMAND_OPEN = "open"
+STATE_CLOSED = "closed"
+STATE_CLOSING = "closing"
+STATE_OPEN = "open"
+STATE_OPENING = "opening"
+STATE_STOPPED = "stopped"
+STATE_TRANSITION = "transition"
+STATE_UNKNOWN = "unknown"
+
+
+class MyQGaragedoor(MyQDevice):
+    """Define a generic device."""
+
+    def __init__(self, api: "API", device_json: dict, account: str) -> None:
+        """Initialize.
+        :type account: str
+        """
+        super().__init__(api=api, account=account, device_json=device_json)
+
+    @property
+    def close_allowed(self) -> bool:
+        """Return whether the device can be closed unattended."""
+        return self.device_json["state"].get("is_unattended_close_allowed") is True
+
+    @property
+    def open_allowed(self) -> bool:
+        """Return whether the device can be opened unattended."""
+        return self.device_json["state"].get("is_unattended_open_allowed") is True
+
+    @property
+    def state(self) -> Optional[str]:
+        """Return the current state of the device."""
+        return (
+            self.device_json["state"].get("door_state")
+            if self.device_json.get("state") is not None
+            else None
+        )
+
+    @state.setter
+    def state(self, value: str) -> None:
+        """Set the current state of the device."""
+        if self.device_json.get("state") is None:
+            return
+        self.device_json["state"]["door_state"] = value
+
+    async def close(self) -> None:
+        """Close the device."""
+        if self.state in (STATE_CLOSED, STATE_CLOSING):
+            return
+
+        # Set the current state to "closing" right away (in case the user doesn't
+        # run update() before checking):
+        self.state = STATE_CLOSING
+        await self._send_state_command(
+            url=COMMAND_URI.format(
+                account_id=self.account,
+                device_serial=self.device_id,
+                command=COMMAND_CLOSE,
+            ),
+            command=COMMAND_CLOSE,
+        )
+
+    async def open(self) -> None:
+        """Open the device."""
+        if self.state in (STATE_OPEN, STATE_OPENING):
+            return
+
+        # Set the current state to "opening" right away (in case the user doesn't
+        # run update() before checking):
+        self.state = STATE_OPENING
+        await self._send_state_command(
+            url=COMMAND_URI.format(
+                account_id=self.account,
+                device_serial=self.device_id,
+                command=COMMAND_OPEN,
+            ),
+            command=COMMAND_OPEN,
+        )

--- a/pymyq/garagedoor.py
+++ b/pymyq/garagedoor.py
@@ -1,5 +1,6 @@
 """Define MyQ devices."""
 import logging
+from asyncio import sleep as asyncio_sleep
 from typing import TYPE_CHECKING, Optional
 
 from .device import MyQDevice
@@ -9,8 +10,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-COMMAND_URI = \
-    "https://account-devices-gdo.myq-cloud.com/api/v5.2/Accounts/{account_id}/door_openers/{device_serial}/{command}"
+COMMAND_URI = "https://account-devices-gdo.myq-cloud.com/api/v5.2/Accounts/{account_id}/door_openers/{device_serial}/{command}"
 COMMAND_CLOSE = "close"
 COMMAND_OPEN = "open"
 STATE_CLOSED = "closed"
@@ -20,6 +20,8 @@ STATE_OPENING = "opening"
 STATE_STOPPED = "stopped"
 STATE_TRANSITION = "transition"
 STATE_UNKNOWN = "unknown"
+
+WAIT_TIMEOUT = 60
 
 
 class MyQGaragedoor(MyQDevice):
@@ -57,36 +59,76 @@ class MyQGaragedoor(MyQDevice):
             return
         self.device_json["state"]["door_state"] = value
 
-    async def close(self) -> None:
+    async def close(self, wait_for_state: bool = False) -> bool:
         """Close the device."""
-        if self.state in (STATE_CLOSED, STATE_CLOSING):
-            return
-
-        # Set the current state to "closing" right away (in case the user doesn't
-        # run update() before checking):
-        self.state = STATE_CLOSING
-        await self._send_state_command(
-            url=COMMAND_URI.format(
-                account_id=self.account,
-                device_serial=self.device_id,
+        if self.state not in (STATE_CLOSED, STATE_CLOSING):
+            # Set the current state to "closing" right away (in case the user doesn't
+            # run update() before checking):
+            self.state = STATE_CLOSING
+            await self._send_state_command(
+                url=COMMAND_URI.format(
+                    account_id=self.account,
+                    device_serial=self.device_id,
+                    command=COMMAND_CLOSE,
+                ),
                 command=COMMAND_CLOSE,
-            ),
-            command=COMMAND_CLOSE,
-        )
+            )
 
-    async def open(self) -> None:
+        if not wait_for_state:
+            return True
+
+        # First wait until door state is actually updated.
+        last_update = self.device_json["state"]["last_update"]
+        wait_timeout = WAIT_TIMEOUT
+        while (
+            last_update == self.device_json["state"]["last_update"] and wait_timeout > 0
+        ):
+            wait_timeout = wait_timeout - 5
+            await asyncio_sleep(5)
+            await self.update()
+
+        # Wait until the state is not closing anymore.
+        wait_timeout = WAIT_TIMEOUT
+        while self.state == STATE_CLOSING and wait_timeout > 0:
+            wait_timeout = wait_timeout - 5
+            await asyncio_sleep(5)
+            await self.update()
+
+        return self.state == STATE_CLOSED
+
+    async def open(self, wait_for_state: bool = False) -> bool:
         """Open the device."""
-        if self.state in (STATE_OPEN, STATE_OPENING):
-            return
-
-        # Set the current state to "opening" right away (in case the user doesn't
-        # run update() before checking):
-        self.state = STATE_OPENING
-        await self._send_state_command(
-            url=COMMAND_URI.format(
-                account_id=self.account,
-                device_serial=self.device_id,
+        if self.state not in (STATE_OPEN, STATE_OPENING):
+            # Set the current state to "opening" right away (in case the user doesn't
+            # run update() before checking):
+            self.state = STATE_OPENING
+            await self._send_state_command(
+                url=COMMAND_URI.format(
+                    account_id=self.account,
+                    device_serial=self.device_id,
+                    command=COMMAND_OPEN,
+                ),
                 command=COMMAND_OPEN,
-            ),
-            command=COMMAND_OPEN,
-        )
+            )
+
+        if not wait_for_state:
+            return True
+
+        # First wait until door state is actually updated.
+        last_update = self.device_json["state"]["last_update"]
+        wait_timeout = WAIT_TIMEOUT
+        while (
+            last_update == self.device_json["state"]["last_update"] and wait_timeout > 0
+        ):
+            wait_timeout = wait_timeout - 5
+            await asyncio_sleep(5)
+            await self.update()
+
+        # Wait until the state is not open anymore.
+        wait_timeout = WAIT_TIMEOUT
+        while self.state == STATE_OPENING and wait_timeout > 0:
+            wait_timeout = wait_timeout - 5
+            await asyncio_sleep(5)
+            await self.update()
+
+        return self.state == STATE_OPEN

--- a/pymyq/garagedoor.py
+++ b/pymyq/garagedoor.py
@@ -80,9 +80,9 @@ class MyQGaragedoor(MyQDevice):
         wait_for_state_task = asyncio.create_task(self.wait_for_state(
             current_state=tuple(STATE_OPENING),
             new_state=tuple(STATE_OPEN),
-            last_state_update=self.device_json["state"]["last_update"]),
-            name="MyQ_Authenticate"
-            )
+            last_state_update=self.device_json["state"].get("last_update"),
+        ), name="MyQ_Authenticate",
+        )
         if not wait_for_state:
             return wait_for_state_task
 
@@ -106,9 +106,10 @@ class MyQGaragedoor(MyQDevice):
         wait_for_state_task = asyncio.create_task(self.wait_for_state(
             current_state=tuple(STATE_OPENING),
             new_state=tuple(STATE_OPEN),
-            last_state_update=self.device_json["state"]["last_update"]),
-            name="MyQ_Authenticate"
-            )
+            last_state_update=self.device_json["state"].get("last_update"),
+        ), name="MyQ_Authenticate",
+        )
+
         if not wait_for_state:
             return wait_for_state_task
 

--- a/pymyq/garagedoor.py
+++ b/pymyq/garagedoor.py
@@ -74,18 +74,16 @@ class MyQGaragedoor(MyQDevice):
             )
             self.state = STATE_CLOSING
 
-        if not wait_for_state:
-            return True
-
         wait_for_state_task = asyncio.create_task(self.wait_for_state(
-            current_state=[STATE_OPENING],
-            new_state=[STATE_OPEN],
+            current_state=[STATE_CLOSING],
+            new_state=[STATE_CLOSED],
             last_state_update=self.device_json["state"].get("last_update"),
         ), name="MyQ_WaitForClose",
         )
         if not wait_for_state:
             return wait_for_state_task
 
+        _LOGGER.debug("Waiting till garage is closed")
         return await wait_for_state_task
 
     async def open(self, wait_for_state: bool = False) -> Union[asyncio.Task, bool]:
@@ -113,4 +111,5 @@ class MyQGaragedoor(MyQDevice):
         if not wait_for_state:
             return wait_for_state_task
 
+        _LOGGER.debug("Waiting till garage is open")
         return await wait_for_state_task

--- a/pymyq/garagedoor.py
+++ b/pymyq/garagedoor.py
@@ -1,6 +1,7 @@
 """Define MyQ devices."""
 import logging
 from asyncio import sleep as asyncio_sleep
+from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from .device import MyQDevice

--- a/pymyq/lamp.py
+++ b/pymyq/lamp.py
@@ -20,11 +20,11 @@ STATE_OFF = "off"
 class MyQLamp(MyQDevice):
     """Define a generic device."""
 
-    def __init__(self, api: "API", device_json: dict, account: str) -> None:
+    def __init__(self, api: "API", device_json: dict, account: str, state_update: datetime) -> None:
         """Initialize.
         :type account: str
         """
-        super().__init__(api=api, account=account, device_json=device_json)
+        super().__init__(api=api, account=account, device_json=device_json, state_update=state_update)
 
     @property
     def state(self) -> Optional[str]:

--- a/pymyq/lamp.py
+++ b/pymyq/lamp.py
@@ -12,8 +12,8 @@ _LOGGER = logging.getLogger(__name__)
 
 COMMAND_URI = \
     "https://account-devices-lamp.myq-cloud.com/api/v5.2/Accounts/{account_id}/lamps/{device_serial}/{command}"
-COMMAND_ON = "turnon"
-COMMAND_OFF = "turnoff"
+COMMAND_ON = "on"
+COMMAND_OFF = "off"
 STATE_ON = "on"
 STATE_OFF = "off"
 

--- a/pymyq/lamp.py
+++ b/pymyq/lamp.py
@@ -28,20 +28,13 @@ class MyQLamp(MyQDevice):
         super().__init__(api=api, account=account, device_json=device_json, state_update=state_update)
 
     @property
-    def state(self) -> Optional[str]:
+    def device_state(self) -> Optional[str]:
         """Return the current state of the device."""
         return (
             self.device_json["state"].get("lamp_state")
             if self.device_json.get("state") is not None
             else None
         )
-
-    @state.setter
-    def state(self, value: str) -> None:
-        """Set the current state of the device."""
-        if self.device_json.get("state") is None:
-            return
-        self.device_json["state"]["lamp_state"] = value
 
     async def turnoff(self) -> None:
         """Close the device."""

--- a/pymyq/lamp.py
+++ b/pymyq/lamp.py
@@ -1,5 +1,6 @@
 """Define MyQ devices."""
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from .device import MyQDevice

--- a/pymyq/lamp.py
+++ b/pymyq/lamp.py
@@ -1,0 +1,77 @@
+"""Define MyQ devices."""
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from .device import MyQDevice
+
+if TYPE_CHECKING:
+    from .api import API
+
+_LOGGER = logging.getLogger(__name__)
+
+COMMAND_URI = \
+    "https://account-devices-lamp.myq-cloud.com/api/v5.2/Accounts/{account_id}/lamps/{device_serial}/{command}"
+COMMAND_ON = "turnon"
+COMMAND_OFF = "turnoff"
+STATE_ON = "on"
+STATE_OFF = "off"
+
+
+class MyQLamp(MyQDevice):
+    """Define a generic device."""
+
+    def __init__(self, api: "API", device_json: dict, account: str) -> None:
+        """Initialize.
+        :type account: str
+        """
+        super().__init__(api=api, account=account, device_json=device_json)
+
+    @property
+    def state(self) -> Optional[str]:
+        """Return the current state of the device."""
+        return (
+            self.device_json["state"].get("lamp_state")
+            if self.device_json.get("state") is not None
+            else None
+        )
+
+    @state.setter
+    def state(self, value: str) -> None:
+        """Set the current state of the device."""
+        if self.device_json.get("state") is None:
+            return
+        self.device_json["state"]["lamp_state"] = value
+
+    async def turnoff(self) -> None:
+        """Close the device."""
+        if self.state == STATE_OFF:
+            return
+
+        # Set the current state to "closing" right away (in case the user doesn't
+        # run update() before checking):
+        self.state = STATE_OFF
+        await self._send_state_command(
+            url=COMMAND_URI.format(
+                account_id=self.account,
+                device_serial=self.device_id,
+                command=COMMAND_OFF,
+            ),
+            command=COMMAND_OFF,
+        )
+
+    async def turnon(self) -> None:
+        """Open the device."""
+        if self.state == STATE_ON:
+            return
+
+        # Set the current state to "opening" right away (in case the user doesn't
+        # run update() before checking):
+        self.state = STATE_ON
+        await self._send_state_command(
+            url=COMMAND_URI.format(
+                account_id=self.account,
+                device_serial=self.device_id,
+                command=COMMAND_ON,
+            ),
+            command=COMMAND_ON,
+        )

--- a/pymyq/request.py
+++ b/pymyq/request.py
@@ -40,7 +40,8 @@ class MyQRequest:  # pylint: disable=too-many-instance-attributes
         while attempt < DEFAULT_REQUEST_RETRIES:
             if attempt != 0:
                 wait_for = min(2 ** attempt, 5)
-                _LOGGER.warning(f'Request failed with "{last_status} {last_error}"; trying again in {wait_for} seconds')
+                _LOGGER.warning(f'Request failed with "{last_status} {last_error}" '
+                                f'(attempt #{attempt}/{DEFAULT_REQUEST_RETRIES})"; trying again in {wait_for} seconds')'
                 await asyncio.sleep(wait_for)
 
             attempt += 1

--- a/pymyq/request.py
+++ b/pymyq/request.py
@@ -40,8 +40,8 @@ class MyQRequest:  # pylint: disable=too-many-instance-attributes
         while attempt < DEFAULT_REQUEST_RETRIES:
             if attempt != 0:
                 wait_for = min(2 ** attempt, 5)
-                _LOGGER.warning(f'Request failed with "{last_status} {last_error}" '
-                                f'(attempt #{attempt}/{DEFAULT_REQUEST_RETRIES})"; trying again in {wait_for} seconds')
+                _LOGGER.debug(f'Request failed with "{last_status} {last_error}" '
+                              f'(attempt #{attempt}/{DEFAULT_REQUEST_RETRIES})"; trying again in {wait_for} seconds')
                 await asyncio.sleep(wait_for)
 
             attempt += 1

--- a/pymyq/request.py
+++ b/pymyq/request.py
@@ -37,7 +37,7 @@ class MyQRequest:  # pylint: disable=too-many-instance-attributes
         resp_exc = None
         last_status = ""
         last_error = ""
-        while attempt < DEFAULT_REQUEST_RETRIES - 1:
+        while attempt < DEFAULT_REQUEST_RETRIES:
             if attempt != 0:
                 wait_for = min(2 ** attempt, 5)
                 _LOGGER.warning(f'Request failed with "{last_status} {last_error}"; trying again in {wait_for} seconds')

--- a/pymyq/request.py
+++ b/pymyq/request.py
@@ -1,0 +1,166 @@
+"""Handle requests to MyQ."""
+import asyncio
+import logging
+from json import JSONDecodeError
+
+from aiohttp import ClientSession, ClientResponse
+from aiohttp.client_exceptions import ClientError, ClientResponseError
+
+from .errors import RequestError
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUEST_METHODS = dict(
+    json="request_json", text="request_text", response="request_response"
+)
+DEFAULT_REQUEST_RETRIES = 5
+
+
+class MyQRequest:  # pylint: disable=too-many-instance-attributes
+    """Define a class to handle requests to MyQ"""
+
+    def __init__(self, websession: ClientSession = None) -> None:
+        self._websession = websession or ClientSession()
+
+    async def _send_request(
+        self,
+        method: str,
+        url: str,
+        headers: dict = None,
+        params: dict = None,
+        data: dict = None,
+        json: dict = None,
+        allow_redirects: bool = False,
+    ) -> ClientResponse:
+
+        attempt = 0
+        resp_exc = None
+        while attempt < DEFAULT_REQUEST_RETRIES - 1:
+            if attempt != 0:
+                wait_for = min(2 ** attempt, 5)
+                _LOGGER.warning(f"Request failed; trying again in {wait_for} seconds")
+                await asyncio.sleep(wait_for)
+
+            attempt += 1
+
+            try:
+                _LOGGER.debug(f"Sending myq api request {url} and headers {headers}")
+                resp = await self._websession.request(
+                    method,
+                    url,
+                    headers=headers,
+                    params=params,
+                    data=data,
+                    json=json,
+                    skip_auto_headers={"USER-AGENT"},
+                    allow_redirects=allow_redirects,
+                    raise_for_status=True,
+                )
+                _LOGGER.debug("Response:")
+                _LOGGER.debug(f"    Response Code: {resp.status}")
+                _LOGGER.debug(f"    Headers: {resp.raw_headers}")
+                _LOGGER.debug(f"    Body: {await resp.text()}")
+                return resp
+            except ClientResponseError as err:
+                _LOGGER.debug(
+                    f"Attempt {attempt} request failed with exception : {err.status} - {err.message}"
+                )
+                if err.status == 401:
+                    raise err
+            except ClientError as err:
+                _LOGGER.debug(
+                    f"Attempt {attempt} request failed with exception:: {str(err)}"
+                )
+                resp_exc = err
+
+        raise resp_exc
+
+    async def request_json(
+        self,
+        method: str,
+        url: str,
+        headers: dict = None,
+        params: dict = None,
+        data: dict = None,
+        json: dict = None,
+        allow_redirects: bool = False,
+    ) -> (ClientResponse, dict):
+
+        resp = await self._send_request(
+            method=method,
+            url=url,
+            headers=headers,
+            params=params,
+            data=data,
+            json=json,
+            allow_redirects=allow_redirects,
+        )
+
+        try:
+            data = await resp.json(content_type=None)
+        except JSONDecodeError as err:
+            message = (
+                f"JSON Decoder error {err.msg} in response at line {err.lineno} column {err.colno}. Response "
+                f"received was:\n{err.doc}"
+            )
+            _LOGGER.error(message)
+            raise RequestError(message)
+
+        return resp, data
+
+    async def request_text(
+        self,
+        method: str,
+        url: str,
+        headers: dict = None,
+        params: dict = None,
+        data: dict = None,
+        json: dict = None,
+        allow_redirects: bool = False,
+    ) -> (ClientResponse, str):
+
+        resp = await self._send_request(
+            method=method,
+            url=url,
+            headers=headers,
+            params=params,
+            data=data,
+            json=json,
+            allow_redirects=allow_redirects,
+        )
+
+        try:
+            data = await resp.text()
+        except JSONDecodeError as err:
+            message = (
+                f"JSON Decoder error {err.msg} in response at line {err.lineno} column {err.colno}. Response "
+                f"received was:\n{err.doc}"
+            )
+            _LOGGER.error(message)
+            raise RequestError(message)
+
+        return resp, data
+
+    async def request_response(
+        self,
+        method: str,
+        url: str,
+        headers: dict = None,
+        params: dict = None,
+        data: dict = None,
+        json: dict = None,
+        allow_redirects: bool = False,
+    ) -> (ClientResponse, None):
+
+        return (
+            await self._send_request(
+                method=method,
+                url=url,
+                headers=headers,
+                params=params,
+                data=data,
+                json=json,
+                allow_redirects=allow_redirects,
+            ),
+            None,
+        )

--- a/pymyq/request.py
+++ b/pymyq/request.py
@@ -41,7 +41,7 @@ class MyQRequest:  # pylint: disable=too-many-instance-attributes
             if attempt != 0:
                 wait_for = min(2 ** attempt, 5)
                 _LOGGER.warning(f'Request failed with "{last_status} {last_error}" '
-                                f'(attempt #{attempt}/{DEFAULT_REQUEST_RETRIES})"; trying again in {wait_for} seconds')'
+                                f'(attempt #{attempt}/{DEFAULT_REQUEST_RETRIES})"; trying again in {wait_for} seconds')
                 await asyncio.sleep(wait_for)
 
             attempt += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -i https://pypi.python.org/simple
 aiohttp>=3.7
+beautifulsoup4>=4.9.3
 pkce>=1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 -i https://pypi.python.org/simple
 aiohttp>=3.7
+pkce>=1.0.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 -i https://pypi.python.org/simple
 aiohttp>=3.7
+beautifulsoup4>=4.9.3
 black==20.8b1
 flake8>=3.8.4
 pkce>=1.0.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,5 +2,6 @@
 aiohttp>=3.7
 black==20.8b1
 flake8>=3.8.4
+pkce>=1.0.2
 twine>=3.3.0
 wheel>=0.36.2


### PR DESCRIPTION
- Update to MyQ V6 API (fixed #67)
- Add support for lamps
- Following properties were added to api:
   - last_state_update:  date/time (UTC) when devices were updated last time (read-only)
   - covers: dictionary of all devices that are covers/garage doors/gates  (read-only)
   - lamps: dictionary of all devices that are lamps  (read-only)
   - gateways: dictionary of all devices that are gateways  (read-only)
   - username: username used to authenticate (read/write)
   - password: password used to authenticate (write-only)
- Following properties were added to MyQDevice:
  - account: Account ID associated with device
  - state_update:  date/time (UTC) when device was updated last time. If this is older then last_state_update property from api then it means the device is not there anymore.
- New classes created:
   - MyQGaragedoor: represents a garage door/gate. Inherits from MyQDevice
   - MyQLamp: represents a lamp. Inherits from MyQDevice
- Methods open & close for garage door have new option wait_for_state (default False). If set to true then open/close will not return until garage door has completed opening/closing and return a Bool. If set the False then a Task object will be returned for the task that is waiting until the state is completed. This task can then be awaited upon for completion of open or close.
- Device updates will automatically occur every 5 seconds when an open or close is send through the API for the garage door/gate.
- Re-authentication is done before token will expire and performed asynchronously so it does not hold up  retrieving device information or sending commands
- Update interval limit set to 10 seconds from 30 seconds
- Changed a number of ERROR or WARNING messages to DEBUG messages and raising exception
- Moved sending of requests into its own class with more detailed debug allowing debug level to be set separate from api