### PR TITLE
v3.1.1

### DIFF
--- a/pymyq/__version__.py
+++ b/pymyq/__version__.py
@@ -1,2 +1,2 @@
 """Define a version constant."""
-__version__ = "3.1.0"
+__version__ = "3.1.1"

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -578,7 +578,12 @@ class API:  # pylint: disable=too-many-instance-attributes
             self.last_state_update = datetime.utcnow()
 
 
-async def login(username: str, password: str, websession: ClientSession = None) -> API:
+async def login(
+    username: str,
+    password: str,
+    websession: ClientSession = None,
+    auth_only: bool = False,
+) -> API:
     """Log in to the API."""
 
     # Set the user agent in the headers.
@@ -593,8 +598,9 @@ async def login(username: str, password: str, websession: ClientSession = None) 
         _LOGGER.error("Authentication failed: %s", str(err))
         raise err
 
-    # Retrieve and store initial set of devices:
-    _LOGGER.debug("Retrieving MyQ information")
-    await api.update_device_info()
+    if not auth_only:
+        # Retrieve and store initial set of devices:
+        _LOGGER.debug("Retrieving MyQ information")
+        await api.update_device_info()
 
     return api

--- a/pymyq/request.py
+++ b/pymyq/request.py
@@ -174,9 +174,17 @@ class MyQRequest:  # pylint: disable=too-many-instance-attributes
                     await self._get_useragent()
 
             except ClientError as err:
-                _LOGGER.debug(
-                    "Attempt %s request failed with exception: %s", attempt, str(err)
-                )
+                if err.errno == 54 and attempt == 0:
+                    _LOGGER.debug(
+                        "Received error status 54, connection reset. Will refresh user agent."
+                    )
+                    await self._get_useragent()
+                else:
+                    _LOGGER.debug(
+                        "Attempt %s request failed with exception: %s",
+                        attempt,
+                        str(err),
+                    )
                 last_status = ""
                 last_error = str(err)
                 resp_exc = err

--- a/pymyq/request.py
+++ b/pymyq/request.py
@@ -112,9 +112,6 @@ class MyQRequest:  # pylint: disable=too-many-instance-attributes
         last_error = ""
 
         for attempt in range(DEFAULT_REQUEST_RETRIES):
-            if self._useragent is None:
-                await self._get_useragent()
-
             if self._useragent is not None and self._useragent != "":
                 headers.update({"User-Agent": self._useragent})
 


### PR DESCRIPTION
- Allow login to check for authentication only without retrieving account and device information
- Also set user agent if error code 54 (connection reset by peer) occurred 
- Do not set user agent unless error occurred on retrieval of page