### PR TITLE
Added support to report low battery for garage doors

### DIFF
--- a/pymyq/garagedoor.py
+++ b/pymyq/garagedoor.py
@@ -52,6 +52,11 @@ class MyQGaragedoor(MyQDevice):
         return self.device_json["state"].get("is_unattended_open_allowed") is True
 
     @property
+    def low_battery(self) -> bool:
+        """Return whether the device has low battery."""
+        return self.device_json["state"].get("dps_low_battery_mode") is True
+
+    @property
     def device_state(self) -> Optional[str]:
         """Return the current state of the device."""
         return (


### PR DESCRIPTION
Noticed one of my garage doors was reporting low battery, so enabled debug and extracted a new value from API response to add a new property to the garage door class to report low battery.

This is what the state key looks like when battery is low:

`      
"state": {
        "dps_battery_critical": false,
        "dps_no_communication": false,
        "dps_low_battery_mode": true,
        "monitor_only_mode": false,
        "number_of_learned_dps_devices": 1,
        "sensor_comm_error": false,
        "is_scheduling_allowed": true,
        "attached_camera_serial_number": "",
        "door_state": "closed",
        "last_update": "2022-12-14T13:24:23.3444945Z",
        "is_unattended_open_allowed": true,
        "is_unattended_close_allowed": true,
        "service_cycle_count": 0,
        "absolute_cycle_count": 0,
        "online": true,
        "last_status": "2022-12-14T17:22:20.719181Z"
}
`

Could some please approve this? Intention is to add this to Home Assistant to report the low battery status of the garage door.