### PR TITLE
Create useragent if one does not exist

### DIFF
--- a/pymyq/request.py
+++ b/pymyq/request.py
@@ -117,9 +117,10 @@ class MyQRequest:  # pylint: disable=too-many-instance-attributes
         last_error = ""
 
         for attempt in range(DEFAULT_REQUEST_RETRIES):
-            if self._useragent is not None and self._useragent != "":
+            if self._useragent is None:
+                await self._get_useragent()
+            if self._useragent != "":
                 headers.update({"User-Agent": self._useragent})
-
             if attempt != 0:
                 wait_for = min(2 ** attempt, 5)
                 _LOGGER.debug(

--- a/pymyq/request.py
+++ b/pymyq/request.py
@@ -170,7 +170,7 @@ class MyQRequest:  # pylint: disable=too-many-instance-attributes
                 last_error = err.message
                 resp_exc = err
 
-                if err.status == 400 and attempt == 0:
+                if err.status in (400, 403) and attempt == 0:
                     _LOGGER.debug(
                         "Received error status 400, bad request. Will refresh user agent."
                     )

--- a/pymyq/request.py
+++ b/pymyq/request.py
@@ -172,7 +172,7 @@ class MyQRequest:  # pylint: disable=too-many-instance-attributes
 
                 if err.status in (400, 403) and attempt == 0:
                     _LOGGER.debug(
-                        "Received error status 400, bad request. Will refresh user agent."
+                        "Received error status %d, bad request. Will refresh user agent.", err.status
                     )
                     await self._get_useragent()
 


### PR DESCRIPTION
Seemingly, the useragent is never created unless there is an exception with a specific error code(And users are getting a 403 error code, not a 400 error code). In my opinion, it is more logical to just create the useragent once at the beginning and still reset it later when needed. That way you also aren't starting with a failed attempt, you can immediately start with a successful attempt. 

Users are seemingly having issues with a request with an empty useragent being rejected.